### PR TITLE
internal/socket: remove spurious break

### DIFF
--- a/internal/socket/relay_actor.go
+++ b/internal/socket/relay_actor.go
@@ -265,7 +265,6 @@ func (a *RelayActor) RemoveRelay(url netaddr.RelayURL) (relay.Config, bool) {
 			ar.setHome(key == next.String())
 		}
 		a.ensureActiveLocked(next, true)
-		break
 	}
 	return prev, true
 }


### PR DESCRIPTION
This removes a `break` that was ending a `for` loop after a single iteration.