### PR TITLE
conn:  close boths end and receive pair to return quic stream

### DIFF
--- a/iroh/conn.go
+++ b/iroh/conn.go
@@ -623,6 +623,22 @@ func (c streamConn) RemoteID() key.EndpointID { return c.remoteID }
 // data. Replay safety is application-specific.
 func (c streamConn) Used0RTT() bool { return c.used0RTT }
 
+// Close closes both stream directions. [Stream.Close] closes only the send
+// direction; CancelRead closes the receive direction, allowing QUIC to retire
+// the stream and replenish stream credit. An already-canceled send direction
+// is treated as closed.
+func (c streamConn) Close() error {
+	err := c.Stream.Close()
+	c.Stream.CancelRead(0)
+	if err != nil {
+		var serr *quic.StreamError
+		if errors.As(context.Cause(c.Stream.Context()), &serr) {
+			return nil
+		}
+	}
+	return err
+}
+
 // connAdapter adapts a qng *quic.Conn to the socket package's
 // [socket.Connection] interface so the per-remote state actor can track its
 // liveness, RTT, and path without the socket package importing iroh.

--- a/iroh/conn_test.go
+++ b/iroh/conn_test.go
@@ -629,6 +629,44 @@ func TestStreamConn(t *testing.T) {
 	}
 }
 
+func TestStreamConnCloseReturnsCredit(t *testing.T) {
+	client, server := connPair(t, "iroh-stream-conn-credit/0")
+	defer client.Close()
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		for i := 0; i < 150; i++ {
+			c, err := server.AcceptStreamConn(ctx)
+			if err != nil {
+				done <- fmt.Errorf("accept stream %d: %w", i, err)
+				return
+			}
+			if err := c.Close(); err != nil {
+				done <- fmt.Errorf("close stream %d: %w", i, err)
+				return
+			}
+		}
+		done <- nil
+	}()
+
+	for i := 0; i < 150; i++ {
+		c, err := client.OpenStreamConn(ctx)
+		if err != nil {
+			t.Fatalf("open stream %d: %v", i, err)
+		}
+		if err := c.Close(); err != nil {
+			t.Fatalf("close stream %d: %v", i, err)
+		}
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSideString(t *testing.T) {
 	tests := []struct {
 		side Side


### PR DESCRIPTION
this ensures we don't exhaust max streams within quic by closing both the send and receiver.