### PR TITLE
socket: Fix public-address discovery and relay-to-direct hole punching

### DIFF
--- a/internal/netreport/client.go
+++ b/internal/netreport/client.go
@@ -47,6 +47,8 @@ type Client struct {
 	// quicConfig overrides QAD transport defaults; if nil, defaultQADConfig is
 	// used.
 	quicConfig *quic.Config
+	// qadDialer, if non-nil, opens QAD probe connections; see WithQADDialer.
+	qadDialer QADDialer
 	// now returns the current time; overridable in tests for deterministic
 	// hysteresis-window pruning.
 	now func() time.Time
@@ -93,6 +95,40 @@ func (c *Client) WithQUICConfig(cfg *quic.Config) *Client {
 func (c *Client) WithQADTLSConfig(cfg *itls.Config) *Client {
 	c.qadTLS = cfg
 	return c
+}
+
+// QADDialer opens the QUIC connection for one QAD probe to addr; tlsConf
+// already carries the QAD ALPN and server name.
+type QADDialer func(ctx context.Context, addr netip.AddrPort, tlsConf *itls.Config, cfg *quic.Config) (*quic.Conn, error)
+
+// WithQADDialer routes QAD probes through d instead of a private per-probe
+// UDP socket, so the observed address is the mapping of the dialer's own
+// socket. A per-probe socket's mapping dies with it and its port is nobody's
+// dial candidate; per-probe mappings also differ between relays, which makes
+// MappingVariesByDest misreport symmetric NAT.
+func (c *Client) WithQADDialer(d QADDialer) *Client {
+	c.qadDialer = d
+	return c
+}
+
+// dialQAD opens the QAD connection for a probe to addr, via the configured
+// dialer or a private per-probe socket.
+func (c *Client) dialQAD(ctx context.Context, addr netip.AddrPort, host string) (*qadConn, error) {
+	if c.qadDialer == nil {
+		return newQADClient(addr, host, c.qadTLS, c.quicConfig)
+	}
+	cfg := c.quicConfig
+	if cfg == nil {
+		cfg = defaultQADConfig()
+	}
+	ctx, cancel := context.WithTimeout(ctx, probesTimeout)
+	defer cancel()
+	conn, err := c.qadDialer(ctx, addr, qadTLSConfig(host, c.qadTLS), cfg)
+	if err != nil {
+		return nil, err
+	}
+	// ownsTransport stays false: the dialer's transport outlives the probe.
+	return &qadConn{conn: conn}, nil
 }
 
 // GetReport runs a single net_report. doFull forces a full report (captive
@@ -230,16 +266,17 @@ func (c *Client) runQADProbe(ctx context.Context, cfg relay.Config, probe Probe)
 		return nil
 	}
 
-	qad, err := newQADClient(addr, host, c.qadTLS, c.quicConfig)
+	qad, err := c.dialQAD(ctx, addr, host)
 	if err != nil {
 		return nil
 	}
 	defer qad.close(qadCloseCode, qadCloseReason)
 
 	// Read the connection RTT (iroh-relay/src/quic.rs:345) and the relay's
-	// observed-address report if one has arrived. observedAddr returns
-	// ErrExtensionNotNegotiated when no report is available yet, in which case
-	// the probe is latency-only.
+	// observed-address report, which observedAddr waits briefly for because it
+	// is sent just after the handshake this dial already completed. It returns
+	// ErrExtensionNotNegotiated when the relay does not report or none arrives
+	// in time, in which case the probe is latency-only.
 	latency := qad.rtt(0)
 	addrPort, addrErr := qad.observedAddr(ctx)
 	rep := &probeReport{probe: probe, relay: cfg.URL, latency: latency}

--- a/internal/netreport/defaults.go
+++ b/internal/netreport/defaults.go
@@ -62,6 +62,10 @@ const (
 	// iroh-relay/src/quic.rs:297.
 	qadKeepAlive = 25 * time.Second
 
+	// qadObservedAddrWait bounds the wait for the relay's OBSERVED_ADDRESS
+	// report after the QAD handshake: one round trip normally, and a relay
+	// that negotiated but never reports must not stall the probe.
+	qadObservedAddrWait = time.Second
 	// qadMaxIdle is the QAD connection idle timeout.
 	// iroh-relay/src/quic.rs:298-300.
 	qadMaxIdle = 35 * time.Second

--- a/internal/netreport/doc.go
+++ b/internal/netreport/doc.go
@@ -24,10 +24,12 @@
 // reflexive address with OBSERVED_ADDRESS frames; the latest report is surfaced
 // as [Report.GlobalV4]/[Report.GlobalV6] (and the matching UDP fields).
 //
-// Reports arrive asynchronously over the connection, so a probe that completes
-// before any report has been received is still treated as latency-only: in that
-// timing window, and when QAD is not negotiated at all,
-// [qadConn.observedAddr] returns [ErrExtensionNotNegotiated] rather than
-// fabricate an address. Relay selection and latency measurement are unaffected
-// either way.
+// Reports arrive after the handshake, so [qadConn.observedAddr] waits briefly
+// for the first one; an immediate read would always miss. Without a report
+// (not negotiated, or timed out) the probe stays latency-only.
+//
+// Which socket a probe rides decides what the observed address means: a
+// private per-probe socket learns a mapping that dies with it.
+// [Client.WithQADDialer] routes probes through the caller's transport instead,
+// so the observed address is the caller's real public mapping.
 package netreport

--- a/internal/netreport/qad.go
+++ b/internal/netreport/qad.go
@@ -13,9 +13,9 @@ import (
 
 // ErrExtensionNotNegotiated is returned by [qadConn.observedAddr] when no
 // reflexive address is available: either QUIC Address Discovery was not
-// negotiated on the connection, or no OBSERVED_ADDRESS report has arrived yet
-// (reports are asynchronous, so a probe can complete first). The forked quic-go
-// implements the extension (slice X3); see the package doc.
+// negotiated on the connection, or no OBSERVED_ADDRESS report arrived within
+// [qadObservedAddrWait]. The forked quic-go implements the extension (slice
+// X3); see the package doc.
 var ErrExtensionNotNegotiated = errors.New("netreport: quic observed-address extension not negotiated")
 
 // qadConn is a client-side QUIC Address Discovery connection to a relay. It
@@ -115,17 +115,18 @@ func (qad *qadConn) rtt(pathID uint64) time.Duration {
 }
 
 // observedAddr returns the host's reflexive address as reported by the relay
-// over the QUIC Address Discovery OBSERVED_ADDRESS extension. When QAD was
-// negotiated and the relay has reported an address, it returns that address.
-// Otherwise it returns [ErrExtensionNotNegotiated] rather than fabricate an
-// address: QAD reports arrive asynchronously, so a probe that completes before
-// any report is treated as latency-only, as is a connection where QAD was not
-// negotiated. See the package doc.
+// via QUIC Address Discovery, waiting up to [qadObservedAddrWait] for the
+// first report — relays send OBSERVED_ADDRESS after the handshake the dial
+// waits for, so an immediate read always loses that race. Returns
+// [ErrExtensionNotNegotiated], without waiting, when the relay did not
+// negotiate address discovery, and when no report arrives in time.
 func (qad *qadConn) observedAddr(ctx context.Context) (netip.AddrPort, error) {
 	if qad.conn == nil {
 		return netip.AddrPort{}, ErrExtensionNotNegotiated
 	}
-	if addr, ok := qad.conn.ObservedAddr(); ok {
+	ctx, cancel := context.WithTimeout(ctx, qadObservedAddrWait)
+	defer cancel()
+	if addr, ok := qad.conn.AwaitObservedAddr(ctx); ok {
 		return addr, nil
 	}
 	return netip.AddrPort{}, ErrExtensionNotNegotiated

--- a/internal/netreport/qad_dialer_test.go
+++ b/internal/netreport/qad_dialer_test.go
@@ -1,0 +1,61 @@
+package netreport
+
+// Coverage for WithQADDialer: a probe must measure the mapping of the socket
+// the dialer rides, and closing the probe must leave that socket alone.
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	tls "github.com/tmc/go-iroh/internal/itls/tls"
+	quic "github.com/tmc/go-iroh/internal/qng"
+)
+
+// TestQADDialerSharesCallerTransport: the observed address is the dialer
+// transport's own address (on loopback, its bound ip:port); round two proves
+// close left the shared transport usable.
+func TestQADDialerSharesCallerTransport(t *testing.T) {
+	serverAddr, stop := startLoopbackQADWithConfig(t, net.IPv4(127, 0, 0, 1), &quic.Config{
+		SendObservedAddressReports: true,
+		KeepAlivePeriod:            100 * time.Millisecond,
+		MaxIdleTimeout:             qadMaxIdle,
+	})
+	defer stop()
+
+	udpConn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer udpConn.Close()
+	tr := &quic.Transport{Conn: udpConn}
+	defer tr.Close()
+
+	c := NewClient(nil).
+		WithQADTLSConfig(&tls.Config{InsecureSkipVerify: true}).
+		WithQADDialer(func(ctx context.Context, addr netip.AddrPort, tlsConf *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+			return tr.Dial(ctx, net.UDPAddrFromAddrPort(addr), tlsConf, cfg)
+		})
+
+	ap := udpConn.LocalAddr().(*net.UDPAddr).AddrPort()
+	want := netip.AddrPortFrom(ap.Addr().Unmap(), ap.Port())
+	ctx := context.Background()
+	for round := range 2 {
+		qad, err := c.dialQAD(ctx, serverAddr, "relay.iroh.invalid")
+		if err != nil {
+			t.Fatalf("round %d: dialQAD: %v", round, err)
+		}
+		got, err := qad.observedAddr(ctx)
+		if err != nil {
+			t.Fatalf("round %d: observedAddr: %v", round, err)
+		}
+		if got != want {
+			t.Fatalf("round %d: observedAddr = %v, want the shared transport's address %v", round, got, want)
+		}
+		if err := qad.close(qadCloseCode, qadCloseReason); err != nil {
+			t.Fatalf("round %d: close: %v", round, err)
+		}
+	}
+}

--- a/internal/netreport/qad_test.go
+++ b/internal/netreport/qad_test.go
@@ -162,28 +162,19 @@ func TestQADObservedAddrLoopback(t *testing.T) {
 			}
 			defer qad.close(qadCloseCode, qadCloseReason)
 
-			deadline := time.Now().Add(5 * time.Second)
-			for {
-				got, err := qad.observedAddr(context.Background())
-				if err == nil {
-					if tt.ip.To4() != nil && !got.Addr().Is4() {
-						t.Fatalf("observedAddr = %v, want IPv4", got)
-					}
-					if tt.ip.To4() == nil && !got.Addr().Is6() {
-						t.Fatalf("observedAddr = %v, want IPv6", got)
-					}
-					if got.Port() == 0 {
-						t.Fatalf("observedAddr = %v, want non-zero port", got)
-					}
-					return
-				}
-				if !errors.Is(err, ErrExtensionNotNegotiated) {
-					t.Fatalf("observedAddr err = %v, want nil or ErrExtensionNotNegotiated", err)
-				}
-				if time.Now().After(deadline) {
-					t.Fatal("observedAddr never received a report")
-				}
-				time.Sleep(20 * time.Millisecond)
+			// Single call, no polling: observedAddr must wait for the report.
+			got, err := qad.observedAddr(context.Background())
+			if err != nil {
+				t.Fatalf("observedAddr: %v", err)
+			}
+			if tt.ip.To4() != nil && !got.Addr().Is4() {
+				t.Fatalf("observedAddr = %v, want IPv4", got)
+			}
+			if tt.ip.To4() == nil && !got.Addr().Is6() {
+				t.Fatalf("observedAddr = %v, want IPv6", got)
+			}
+			if got.Port() == 0 {
+				t.Fatalf("observedAddr = %v, want non-zero port", got)
 			}
 		})
 	}
@@ -209,4 +200,35 @@ func selfSignedCert(t *testing.T) tls.Certificate {
 		t.Fatal(err)
 	}
 	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: priv}
+}
+
+// TestQADObservedAddrNotNegotiatedReturnsPromptly pins the other half of the
+// wait: a relay that never reports must not cost the probe its whole budget.
+func TestQADObservedAddrNotNegotiatedReturnsPromptly(t *testing.T) {
+	addr, stop := startLoopbackQADWithConfig(t, net.IPv4(127, 0, 0, 1), &quic.Config{
+		// Address discovery deliberately not offered by the server.
+		KeepAlivePeriod: 100 * time.Millisecond,
+		MaxIdleTimeout:  qadMaxIdle,
+	})
+	defer stop()
+
+	qad, err := newQADClient(addr, "relay.iroh.invalid",
+		&tls.Config{InsecureSkipVerify: true},
+		&quic.Config{
+			ReceiveObservedAddressReports: true,
+			KeepAlivePeriod:               100 * time.Millisecond,
+			MaxIdleTimeout:                qadMaxIdle,
+		})
+	if err != nil {
+		t.Fatalf("newQADClient: %v", err)
+	}
+	defer qad.close(qadCloseCode, qadCloseReason)
+
+	start := time.Now()
+	if _, err := qad.observedAddr(context.Background()); !errors.Is(err, ErrExtensionNotNegotiated) {
+		t.Fatalf("observedAddr err = %v, want ErrExtensionNotNegotiated", err)
+	}
+	if elapsed := time.Since(start); elapsed >= qadObservedAddrWait {
+		t.Fatalf("waited %v for a relay that never reports; want a prompt return", elapsed)
+	}
 }

--- a/internal/qng/connection.go
+++ b/internal/qng/connection.go
@@ -236,6 +236,9 @@ type Conn struct {
 	observedAddrSeqNo  uint64
 	observedAddrValid  bool
 	observedAddrSeqSet bool
+	// observedAddrReadyCh is closed at the first report so a reader can wait
+	// instead of polling; created lazily under observedAddrMu.
+	observedAddrReadyCh chan struct{}
 
 	streamsMap      *streamsMap
 	connIDManager   *connIDManager
@@ -3233,10 +3236,14 @@ func (c *Conn) handleObservedAddrFrame(frame *wire.ObservedAddrFrame) error {
 		// Stale or duplicate report; ignore (paths.rs:621-622).
 		return nil
 	}
+	first := !c.observedAddrValid
 	c.observedAddrSeqNo = frame.SeqNo
 	c.observedAddrSeqSet = true
 	c.observedAddr = netip.AddrPortFrom(frame.Addr.Unmap(), frame.Port)
 	c.observedAddrValid = true
+	if first {
+		close(c.observedAddrReadyLocked())
+	}
 	return nil
 }
 
@@ -3278,6 +3285,44 @@ func (c *Conn) ObservedAddr() (netip.AddrPort, bool) {
 		return netip.AddrPort{}, false
 	}
 	return c.observedAddr, true
+}
+
+// observedAddrReadyLocked returns the channel closed on the first report,
+// creating it on demand. observedAddrMu must be held.
+func (c *Conn) observedAddrReadyLocked() chan struct{} {
+	if c.observedAddrReadyCh == nil {
+		c.observedAddrReadyCh = make(chan struct{})
+	}
+	return c.observedAddrReadyCh
+}
+
+// AwaitObservedAddr returns the reflexive address the peer reported via the
+// QUIC Address Discovery OBSERVED_ADDRESS extension, waiting for the first
+// report if none has arrived yet (reports are sent after the handshake, so an
+// immediate read misses). Returns ok=false without waiting when address
+// discovery was not negotiated to receive reports, and when ctx ends or the
+// connection closes first.
+func (c *Conn) AwaitObservedAddr(ctx context.Context) (netip.AddrPort, bool) {
+	c.observedAddrMu.Lock()
+	if c.observedAddrValid {
+		addr := c.observedAddr
+		c.observedAddrMu.Unlock()
+		return addr, true
+	}
+	ready := c.observedAddrReadyLocked()
+	c.observedAddrMu.Unlock()
+
+	if !c.acceptsObservedAddr() {
+		return netip.AddrPort{}, false
+	}
+	select {
+	case <-ready:
+		return c.ObservedAddr()
+	case <-ctx.Done():
+		return netip.AddrPort{}, false
+	case <-c.Context().Done():
+		return netip.AddrPort{}, false
+	}
 }
 
 func (c *Conn) triggerSending(now monotime.Time) error {

--- a/internal/qng/qnt.go
+++ b/internal/qng/qnt.go
@@ -50,6 +50,25 @@ type qntLocalState struct {
 	validatedProbes        []netip.AddrPort
 	retryAttempt           uint8
 	nextRetry              monotime.Time
+	// remoteReady is closed once the remote candidate set first becomes
+	// non-empty; created lazily under mu.
+	remoteReady     chan struct{}
+	remoteReadyDone bool
+}
+
+func (st *qntLocalState) remoteReadyChLocked() chan struct{} {
+	if st.remoteReady == nil {
+		st.remoteReady = make(chan struct{})
+	}
+	return st.remoteReady
+}
+
+func (st *qntLocalState) signalRemoteReadyLocked() {
+	if st.remoteReadyDone {
+		return
+	}
+	st.remoteReadyDone = true
+	close(st.remoteReadyChLocked())
 }
 
 type qntLocalAddress struct {
@@ -145,6 +164,7 @@ func (c *Conn) AddRemoteNATTraversalAddress(addr netip.AddrPort) error {
 	seq := st.nextRemoteAddressSeqNo
 	st.nextRemoteAddressSeqNo++
 	st.remote.addrs[seq] = addr
+	st.signalRemoteReadyLocked()
 	return nil
 }
 
@@ -183,6 +203,18 @@ func (c *Conn) InitiateNATTraversalRound(ctx context.Context) ([]netip.AddrPort,
 	st.mu.Unlock()
 	c.qntQueuePendingReachOutFrames()
 	return remote, nil
+}
+
+// NATTraversalRemoteAddrsReady returns a channel closed once this connection
+// first knows a remote NAT traversal candidate (peer ADD_ADDRESS frame or
+// [Conn.AddRemoteNATTraversalAddress]) — the earliest moment a QNT round can
+// start. It never closes when no candidate ever arrives, e.g. on the server
+// side of QNT, which receives no ADD_ADDRESS.
+func (c *Conn) NATTraversalRemoteAddrsReady() <-chan struct{} {
+	st := c.qntLocalState()
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.remoteReadyChLocked()
 }
 
 // NATTraversalAddresses returns the remote ADD_ADDRESS set known to qng.
@@ -660,6 +692,9 @@ func (c *Conn) addRemoteNATTraversalAddressFrame(frame *wire.AddAddressFrame) er
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	_, _, err := st.remote.add(frame)
+	if err == nil && len(st.remote.addresses()) > 0 {
+		st.signalRemoteReadyLocked()
+	}
 	return err
 }
 

--- a/internal/socket/remote_state.go
+++ b/internal/socket/remote_state.go
@@ -368,12 +368,23 @@ func (a *RemoteStateActor) run(ctx context.Context) {
 		case <-heartbeat.C:
 			a.reselect()
 		case <-upgrade.C:
-			// Upgrade tick: first ask qng to validate a direct RFC 9000 path, then
-			// try a QNT round when the active connection supports it. Errors are
-			// non-fatal; the actor keeps using the best path it already knows and
-			// tries again on the next cadence.
-			_ = a.ValidateDirectPath(context.Background())
-			_ = a.TriggerHolepunch()
+			// Upgrade tick: fallback behind the punch-on-ready trigger.
+			// Direct selected: nothing to upgrade toward. Relay selected:
+			// only a punch can help — ValidateDirectPath opens a path over
+			// the current four-tuple (the relay itself) and just burns its
+			// timeout. Off-loop: they block for seconds and the actor must
+			// keep processing messages.
+			sel, selected := a.SelectedPath()
+			switch {
+			case selected && sel.Kind() == AddrIP:
+			case selected && sel.Kind() == AddrRelay:
+				go func() { _ = a.TriggerHolepunch() }()
+			default:
+				go func() {
+					_ = a.ValidateDirectPath(context.Background())
+					_ = a.TriggerHolepunch()
+				}()
+			}
 			a.reselect()
 		}
 		// Keep the idle timer disarmed (reset to a fresh full timeout) while

--- a/internal/socket/remote_state.go
+++ b/internal/socket/remote_state.go
@@ -861,6 +861,32 @@ func (a *RemoteStateActor) TriggerHolepunch() error {
 	if target == nil {
 		return ErrExtensionNotNegotiated
 	}
+	return a.triggerHolepunch(target, candidates)
+}
+
+// TriggerHolepunchConn attempts NAT traversal on conn. It returns
+// [context.Canceled] if conn is no longer registered, or
+// [ErrExtensionNotNegotiated] if conn does not support QNT.
+func (a *RemoteStateActor) TriggerHolepunchConn(conn Connection) error {
+	a.mu.Lock()
+	_, registered := a.conns[conn]
+	candidates := append([]netip.AddrPort(nil), a.localNAT...)
+	a.mu.Unlock()
+	if !registered {
+		return context.Canceled
+	}
+	mp, ok := conn.(multipathConnection)
+	if !ok || !mp.MultipathNegotiated() {
+		return ErrExtensionNotNegotiated
+	}
+	target, ok := conn.(natTraversalRoundConnection)
+	if !ok {
+		return ErrExtensionNotNegotiated
+	}
+	return a.triggerHolepunch(target, candidates)
+}
+
+func (a *RemoteStateActor) triggerHolepunch(target natTraversalRoundConnection, candidates []netip.AddrPort) error {
 	if a.metrics != nil {
 		a.metrics.holepunchAttempts.Add(1)
 	}

--- a/internal/socket/remotemap_test.go
+++ b/internal/socket/remotemap_test.go
@@ -467,6 +467,36 @@ func TestActorHolepunchGated(t *testing.T) {
 	}
 }
 
+func TestActorTriggerHolepunchConnUsesRequestedConnection(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := NewRemoteMap(ctx, BiasedRttPathSelector{}, nil)
+		id := testEndpointID(t)
+
+		first := newFakeConn(IPAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 9)), time.Millisecond)
+		first.multipathNegotiated = true
+		defer first.Close()
+		_, actor := m.AddConnectionActor(id, first)
+
+		second := newFakeConn(IPAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 10)), time.Millisecond)
+		second.multipathNegotiated = true
+		defer second.Close()
+		m.AddConnection(id, second)
+		synctest.Wait()
+
+		if err := actor.TriggerHolepunchConn(second); err != nil {
+			t.Fatal(err)
+		}
+		if got := first.initiateRoundCalls.Load(); got != 0 {
+			t.Fatalf("first connection InitiateNATTraversalRound calls = %d, want 0", got)
+		}
+		if got := second.initiateRoundCalls.Load(); got != 1 {
+			t.Fatalf("second connection InitiateNATTraversalRound calls = %d, want 1", got)
+		}
+	})
+}
+
 // TestActorSendDatagramBlackhole asserts the blackhole invariant: SendDatagram
 // never returns an error, even when no path is reachable (send returns false).
 func TestActorSendDatagramBlackhole(t *testing.T) {

--- a/internal/socket/remotemap_test.go
+++ b/internal/socket/remotemap_test.go
@@ -385,6 +385,8 @@ func TestActorHeartbeatSyncsQNGRoutes(t *testing.T) {
 	})
 }
 
+// TestActorUpgradeTickStartsQNT asserts the upgrade tick punches while the
+// selected path is RELAYED — the state a punch can actually improve.
 func TestActorUpgradeTickStartsQNT(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -392,7 +394,7 @@ func TestActorUpgradeTickStartsQNT(t *testing.T) {
 		m := NewRemoteMap(ctx, BiasedRttPathSelector{}, nil)
 		id := testEndpointID(t)
 
-		conn := newFakeConn(IPAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 9)), time.Millisecond)
+		conn := newFakeConn(relayPath(t, 1), time.Millisecond)
 		conn.multipathNegotiated = true
 		defer conn.Close()
 		events := m.AddConnection(id, conn)
@@ -414,6 +416,38 @@ func TestActorUpgradeTickStartsQNT(t *testing.T) {
 		synctest.Wait()
 		if got := conn.initiateRoundCalls.Load(); got != 1 {
 			t.Fatalf("InitiateNATTraversalRound calls after upgrade = %d, want 1", got)
+		}
+		cancel()
+		synctest.Wait()
+		<-eventsDone
+	})
+}
+
+// TestActorUpgradeTickSkipsDirectSelected: a direct-selected connection gets
+// no QNT round from the tick.
+func TestActorUpgradeTickSkipsDirectSelected(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		m := NewRemoteMap(ctx, BiasedRttPathSelector{}, nil)
+		id := testEndpointID(t)
+
+		conn := newFakeConn(IPAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 9)), time.Millisecond)
+		conn.multipathNegotiated = true
+		defer conn.Close()
+		events := m.AddConnection(id, conn)
+		eventsDone := make(chan struct{})
+		go func() {
+			for range events {
+			}
+			close(eventsDone)
+		}()
+		synctest.Wait()
+
+		time.Sleep(UpgradeInterval + time.Nanosecond)
+		synctest.Wait()
+		if got := conn.initiateRoundCalls.Load(); got != 0 {
+			t.Fatalf("InitiateNATTraversalRound calls on a direct-selected conn = %d, want 0", got)
 		}
 		cancel()
 		synctest.Wait()

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/tmc/go-iroh/dns"
+	itls "github.com/tmc/go-iroh/internal/itls/tls"
 	"github.com/tmc/go-iroh/internal/netreport"
 	"github.com/tmc/go-iroh/internal/portmapper"
 	quic "github.com/tmc/go-iroh/internal/qng"
@@ -60,12 +61,17 @@ type Endpoint struct {
 	closedCh    chan struct{}
 	acceptOwner acceptOwner
 	addrWatch   *watch.Value[netaddr.EndpointAddr]
-	externalNAT []netip.AddrPort
-	netReport   netReportRunner
-	lastReport  *NetReport
-	nextStable  uint64
-	stableIDs   map[*quic.Conn]uint64
-	metrics     endpointMetrics
+	// externalPinned holds addresses pinned via AddExternalAddr until
+	// RemoveExternalAddr. externalDiscovered holds the latest net report's
+	// reflexive addresses, replaced wholesale per report. Kept apart so a
+	// report cannot drop pinned candidates, nor pinning keep stale ones.
+	externalPinned     []netip.AddrPort
+	externalDiscovered []netip.AddrPort
+	netReport          netReportRunner
+	lastReport         *NetReport
+	nextStable         uint64
+	stableIDs          map[*quic.Conn]uint64
+	metrics            endpointMetrics
 }
 
 type acceptOwner int
@@ -466,9 +472,11 @@ func Bind(ctx context.Context, opts ...Option) (*Endpoint, error) {
 		custom:       append([]CustomTransport(nil), c.custom...),
 		lookup:       c.lookup,
 		closedCh:     make(chan struct{}),
-		netReport:    endpointNetReportRunner(c, relayMap),
 		stableIDs:    make(map[*quic.Conn]uint64),
 	}
+	// Assigned after the literal: the runner needs ep.transport so QAD
+	// probes ride the endpoint's own socket (see qadDialer).
+	ep.netReport = endpointNetReportRunner(c, relayMap, ep.qadDialer())
 	// The per-remote state registry shares the serve context: its actors stop
 	// when the endpoint's recv loop stops. Its resolve hook is backed by the
 	// endpoint's address-lookup services (slice G), passed down as a func value
@@ -522,7 +530,7 @@ func (e *Endpoint) sourceAddressValidation() func(net.Addr) bool {
 	return e.verifySource
 }
 
-func endpointNetReportRunner(c config, relayMap *relay.Map) netReportRunner {
+func endpointNetReportRunner(c config, relayMap *relay.Map, dialer netreport.QADDialer) netReportRunner {
 	if c.netReport != nil {
 		return c.netReport
 	}
@@ -530,8 +538,25 @@ func endpointNetReportRunner(c config, relayMap *relay.Map) netReportRunner {
 		return nil
 	}
 	client := netreport.NewClient(relayMap)
+	if dialer != nil {
+		client = client.WithQADDialer(dialer)
+	}
 	return func(ctx context.Context) (*netreport.Report, error) {
 		return client.GetReport(ctx, netreport.IfStateDetails{HaveV4: true, HaveV6: true}, false)
+	}
+}
+
+// qadDialer returns the dialer net_report uses for QAD probes. Dials on the
+// endpoint's own transport share its UDP socket, so the address a relay
+// observes is the endpoint's real public mapping — a usable dial and
+// hole-punch candidate. Nil when there is no IP transport; net_report then
+// falls back to a private per-probe socket.
+func (e *Endpoint) qadDialer() netreport.QADDialer {
+	if e.udp == nil {
+		return nil
+	}
+	return func(ctx context.Context, addr netip.AddrPort, tlsConf *itls.Config, cfg *quic.Config) (*quic.Conn, error) {
+		return e.transport.Dial(ctx, net.UDPAddrFromAddrPort(addr), tlsConf, cfg)
 	}
 }
 
@@ -615,6 +640,16 @@ func (e *Endpoint) LocalAddr() netip.AddrPort {
 	return e.udp.LocalAddr().(*net.UDPAddr).AddrPort()
 }
 
+// externalNATLocked returns the pinned and net-report-discovered external
+// candidates, pinned first, deduplicated. e.mu must be held.
+func (e *Endpoint) externalNATLocked() []netip.AddrPort {
+	out := append([]netip.AddrPort(nil), e.externalPinned...)
+	for _, addr := range e.externalDiscovered {
+		out = appendUniqueNATTraversalCandidate(out, addr)
+	}
+	return out
+}
+
 // localNATTraversalCandidates returns concrete local direct addresses this
 // endpoint can hand to qng's QNT state. The default bind address is unspecified
 // ([::]:port), which is not a usable candidate and must not be advertised.
@@ -629,7 +664,7 @@ func (e *Endpoint) localNATTraversalCandidates() []netip.AddrPort {
 		addrs = appendUniqueNATTraversalCandidate(addrs, addr)
 	}
 	e.mu.Lock()
-	external := append([]netip.AddrPort(nil), e.externalNAT...)
+	external := e.externalNATLocked()
 	e.mu.Unlock()
 	for _, addr := range external {
 		addrs = appendUniqueNATTraversalCandidate(addrs, addr)
@@ -637,6 +672,9 @@ func (e *Endpoint) localNATTraversalCandidates() []netip.AddrPort {
 	return addrs
 }
 
+// setExternalNATTraversalCandidates replaces the discovered external
+// candidate set: net reports are authoritative, and replacement retires
+// mappings the NAT rebound. Pinned addresses are a separate set.
 func (e *Endpoint) setExternalNATTraversalCandidates(addrs ...netip.AddrPort) bool {
 	var next []netip.AddrPort
 	for _, addr := range addrs {
@@ -644,11 +682,11 @@ func (e *Endpoint) setExternalNATTraversalCandidates(addrs ...netip.AddrPort) bo
 	}
 
 	e.mu.Lock()
-	if equalAddrPorts(e.externalNAT, next) {
+	if equalAddrPorts(e.externalDiscovered, next) {
 		e.mu.Unlock()
 		return false
 	}
-	e.externalNAT = next
+	e.externalDiscovered = next
 	e.updateAddrWatchLocked()
 	e.mu.Unlock()
 
@@ -656,20 +694,20 @@ func (e *Endpoint) setExternalNATTraversalCandidates(addrs ...netip.AddrPort) bo
 	return true
 }
 
-// AddExternalAddr adds addr to the endpoint's externally reachable addresses
-// and advertises it as a QNT NAT traversal candidate. Invalid, unspecified, or
-// zero-port addresses are ignored.
+// AddExternalAddr pins addr as an externally reachable address and advertises
+// it as a QNT NAT traversal candidate until RemoveExternalAddr; net reports
+// never drop it. Invalid, unspecified, or zero-port addresses are ignored.
 func (e *Endpoint) AddExternalAddr(addr netip.AddrPort) {
 	if e.disableIP {
 		return
 	}
 	e.mu.Lock()
-	next := appendUniqueNATTraversalCandidate(append([]netip.AddrPort(nil), e.externalNAT...), addr)
-	if equalAddrPorts(e.externalNAT, next) {
+	next := appendUniqueNATTraversalCandidate(append([]netip.AddrPort(nil), e.externalPinned...), addr)
+	if equalAddrPorts(e.externalPinned, next) {
 		e.mu.Unlock()
 		return
 	}
-	e.externalNAT = next
+	e.externalPinned = next
 	e.updateAddrWatchLocked()
 	e.mu.Unlock()
 	e.advertiseNATTraversalCandidates()
@@ -689,12 +727,12 @@ func (e *Endpoint) RemoveExternalAddr(addr netip.AddrPort) bool {
 	}
 
 	e.mu.Lock()
-	i := slices.Index(e.externalNAT, addr)
+	i := slices.Index(e.externalPinned, addr)
 	if i < 0 {
 		e.mu.Unlock()
 		return false
 	}
-	e.externalNAT = slices.Delete(e.externalNAT, i, i+1)
+	e.externalPinned = slices.Delete(e.externalPinned, i, i+1)
 	e.updateAddrWatchLocked()
 	e.mu.Unlock()
 	e.advertiseNATTraversalCandidates()
@@ -892,7 +930,7 @@ func (e *Endpoint) Addr() netaddr.EndpointAddr {
 		a = a.WithIP(e.LocalAddr())
 	}
 	e.mu.Lock()
-	external := append([]netip.AddrPort(nil), e.externalNAT...)
+	external := e.externalNATLocked()
 	e.mu.Unlock()
 	if !e.disableIP {
 		for _, addr := range external {
@@ -935,7 +973,7 @@ func (e *Endpoint) addrLocked() netaddr.EndpointAddr {
 	a := netaddr.NewEndpointAddr(e.ID())
 	if !e.disableIP {
 		a = a.WithIP(e.LocalAddr())
-		for _, addr := range e.externalNAT {
+		for _, addr := range e.externalNATLocked() {
 			a = a.WithIP(addr)
 		}
 	}
@@ -1414,9 +1452,18 @@ func (e *Endpoint) registerConn(remote key.EndpointID, qc *quic.Conn, remoteAddr
 	// hole-punch calls.
 	_ = actor.AddNATTraversalAddresses(e.localNATTraversalCandidates())
 	_ = actor.AddRemoteNATTraversalAddresses(remoteAddr.IPAddrs())
-	if len(remoteAddr.IPAddrs()) != 0 {
-		_ = actor.TriggerHolepunch()
-	}
+	// Punch as soon as a remote candidate is known instead of waiting for
+	// the 60s upgrade tick: immediately when the dial carried IP addresses
+	// (the seed above closed the channel), or when the server's first
+	// ADD_ADDRESS lands after a relay-won dial. The server side of QNT
+	// receives no ADD_ADDRESS and parks here until the connection closes.
+	go func() {
+		select {
+		case <-qc.NATTraversalRemoteAddrsReady():
+			_ = actor.TriggerHolepunch()
+		case <-qc.Context().Done():
+		}
+	}()
 	return actor, adapter
 }
 

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -1460,7 +1460,7 @@ func (e *Endpoint) registerConn(remote key.EndpointID, qc *quic.Conn, remoteAddr
 	go func() {
 		select {
 		case <-qc.NATTraversalRemoteAddrsReady():
-			_ = actor.TriggerHolepunch()
+			_ = actor.TriggerHolepunchConn(adapter)
 		case <-qc.Context().Done():
 		}
 	}()

--- a/iroh/endpoint_external_pinned_test.go
+++ b/iroh/endpoint_external_pinned_test.go
@@ -1,0 +1,67 @@
+package iroh
+
+// A net report replacing the discovered set must never drop addresses pinned
+// with AddExternalAddr.
+
+import (
+	"context"
+	"net/netip"
+	"slices"
+	"testing"
+)
+
+func TestPinnedExternalAddrSurvivesNetReport(t *testing.T) {
+	ctx := context.Background()
+	ep, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.MustParseAddr("127.0.0.1"), 0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ep.Shutdown(ctx)
+
+	pinned := netip.MustParseAddrPort("192.0.2.7:1111")
+	discovered1 := netip.MustParseAddrPort("203.0.113.10:4444")
+	discovered2 := netip.MustParseAddrPort("203.0.113.11:5555")
+
+	ep.AddExternalAddr(pinned)
+	if !ep.setExternalNATTraversalCandidates(discovered1) {
+		t.Fatal("first setExternalNATTraversalCandidates = false, want true")
+	}
+
+	got := ep.localNATTraversalCandidates()
+	for _, want := range []netip.AddrPort{pinned, discovered1} {
+		if !slices.Contains(got, want) {
+			t.Fatalf("candidates after report = %v, missing %v", got, want)
+		}
+	}
+
+	// The next report replaces the discovered set: the old mapping retires,
+	// the pinned address stays.
+	if !ep.setExternalNATTraversalCandidates(discovered2) {
+		t.Fatal("second setExternalNATTraversalCandidates = false, want true")
+	}
+	got = ep.localNATTraversalCandidates()
+	if !slices.Contains(got, pinned) {
+		t.Fatalf("candidates after second report = %v, pinned %v was dropped", got, pinned)
+	}
+	if !slices.Contains(got, discovered2) {
+		t.Fatalf("candidates after second report = %v, missing %v", got, discovered2)
+	}
+	if slices.Contains(got, discovered1) {
+		t.Fatalf("candidates after second report = %v, stale discovered %v not retired", got, discovered1)
+	}
+	if ips := ep.Addr().IPAddrs(); !slices.Contains(ips, pinned) {
+		t.Fatalf("Addr() = %v, pinned %v missing", ep.Addr(), pinned)
+	}
+
+	// Unpinning removes it everywhere; the discovered mapping is untouched.
+	if !ep.RemoveExternalAddr(pinned) {
+		t.Fatal("RemoveExternalAddr = false, want true")
+	}
+	got = ep.localNATTraversalCandidates()
+	if slices.Contains(got, pinned) {
+		t.Fatalf("candidates after unpin = %v, %v still present", got, pinned)
+	}
+	if !slices.Contains(got, discovered2) {
+		t.Fatalf("candidates after unpin = %v, discovered %v lost", got, discovered2)
+	}
+}

--- a/iroh/upgrade_test.go
+++ b/iroh/upgrade_test.go
@@ -1,0 +1,95 @@
+package iroh
+
+// A connection dialed knowing only the relay must reach a validated,
+// SELECTED direct path shortly after the handshake — punch-on-ready, not the
+// 60s upgrade tick. Selection is what carries the bytes.
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/tmc/go-iroh/key"
+	"github.com/tmc/go-iroh/netaddr"
+	"github.com/tmc/go-iroh/relay"
+)
+
+func TestRelayToDirectUpgrade(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	srv := newEchoRelayServer(t)
+	relayURL := srv.url(t)
+	mode := relay.ModeCustom(relay.MapFromURLs(relayURL))
+	const alpn = "upgrade-test/0"
+
+	srvKey, _ := key.GenerateSecretKey()
+	server, err := Bind(ctx,
+		WithSecretKey(srvKey),
+		WithALPNs(alpn),
+		WithRelayMode(mode),
+		WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Shutdown(ctx)
+
+	client, err := Bind(ctx,
+		WithRelayMode(mode),
+		WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown(ctx)
+
+	if err := server.Online(ctx); err != nil {
+		t.Fatalf("server online: %v", err)
+	}
+	if err := client.Online(ctx); err != nil {
+		t.Fatalf("client online: %v", err)
+	}
+
+	go func() {
+		conn, err := server.Accept(ctx)
+		if err != nil {
+			return
+		}
+		<-conn.Context().Done()
+	}()
+
+	// Relay-only address, as when the relay wins a candidate race: everything
+	// direct must be learned over the connection itself.
+	addr := netaddr.NewEndpointAddr(server.ID()).WithRelayURL(relayURL)
+	conn, err := client.Connect(ctx, addr, alpn)
+	if err != nil {
+		t.Fatalf("relay connect: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	for _, p := range conn.Paths() {
+		if !p.Relayed {
+			t.Fatalf("premise broken: direct path present right after a relay-only dial: %+v", p)
+		}
+	}
+
+	// ~5s locally (ADD_ADDRESS round trip + 5s heartbeat reselect); 30s is
+	// CI headroom. First-punch-at-60s fails this bound.
+	deadline := time.Now().Add(30 * time.Second)
+	start := time.Now()
+	for time.Now().Before(deadline) {
+		for _, p := range conn.Paths() {
+			if !p.Relayed && p.Selected && p.HasAddr && p.Validated {
+				t.Logf("direct path selected after %v: %v", time.Since(start).Round(time.Second), p.Addr)
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	for _, p := range conn.Paths() {
+		t.Logf("path: relayed=%v addr=%v validated=%v selected=%v", p.Relayed, p.Addr, p.Validated, p.Selected)
+	}
+	t.Fatal("relay-only connection never migrated to a selected direct path")
+}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -80,11 +80,15 @@ func NewMap(configs ...Config) *Map {
 	return m
 }
 
-// MapFromURLs builds a Map from relay URLs, each with a default config.
+// MapFromURLs builds a Map from relay URLs, each with a default config that
+// enables QUIC address discovery on [DefaultQUICPort]. net_report only probes
+// relays whose config has a QUIC section, so a nil default would disable
+// address discovery for every URL-built map, including [DefaultMap]. A relay
+// without QAD just fails the probe, which stays latency-only.
 func MapFromURLs(urls ...netaddr.RelayURL) *Map {
 	configs := make([]Config, len(urls))
 	for i, u := range urls {
-		configs[i] = Config{URL: u}
+		configs[i] = Config{URL: u, QUIC: &QUICConfig{Port: DefaultQUICPort}}
 	}
 	return NewMap(configs...)
 }


### PR DESCRIPTION
Endpoints could never learn their own public address, and a relayed connection never upgraded to a direct path.

- relay: MapFromURLs left Config.QUIC nil, so net_report never ran a QAD probe with any URL-built map, including DefaultMap. Enable QUIC address discovery on DefaultQUICPort by default.
- netreport: the observed-address read raced the relay's post-handshake report and always lost. Conn.AwaitObservedAddr waits for the first report; the probe bounds the wait with qadObservedAddrWait.
- netreport: probes dialed from a throwaway socket, so the observed mapping died with it and its port was nobody's dial candidate; and with a different mapping per probe, relays disagreed and MappingVariesByDest misreported symmetric NAT. Client.WithQADDialer routes probes through a caller-supplied transport; iroh endpoints pass one bound to their own socket.
- iroh: net reports replaced the whole external candidate set, dropping addresses pinned with AddExternalAddr. Pinned and discovered are now separate sets, unioned by readers.
- iroh, qng, socket: nothing punched when a relay-won dial learned the peer's candidates; the first attempt waited for the 60s upgrade tick. Conn.NATTraversalRemoteAddrsReady closes when the first remote candidate arrives and registerConn punches on it: a relay-forced connection reaches a selected direct path in 5s, was 65s. The tick is now a fallback that skips direct-selected connections and no longer runs ValidateDirectPath on relayed ones — it opens a path over the current four-tuple, the relay itself, so it only stalled the actor and leaked a path per tick.