### PR TITLE
iroh: don't advertise the unspecified bind address

### DIFF
--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -927,7 +927,14 @@ func equalAddrPorts(a, b []netip.AddrPort) bool {
 func (e *Endpoint) Addr() netaddr.EndpointAddr {
 	a := netaddr.NewEndpointAddr(e.ID())
 	if !e.disableIP {
-		a = a.WithIP(e.LocalAddr())
+		// The bind address is unspecified ([::]:port) unless the caller chose
+		// one, and that is not something a peer can dial: it means "every
+		// interface on that host". Advertising it gives peers a target that
+		// resolves to their own loopback, and it makes NAT traversal probes
+		// arrive from a source the connection does not recognize.
+		if addr, ok := canonicalNATTraversalCandidate(e.LocalAddr()); ok {
+			a = a.WithIP(addr)
+		}
 	}
 	e.mu.Lock()
 	external := e.externalNATLocked()
@@ -972,7 +979,9 @@ func endpointAddrEqual(a, b netaddr.EndpointAddr) bool {
 func (e *Endpoint) addrLocked() netaddr.EndpointAddr {
 	a := netaddr.NewEndpointAddr(e.ID())
 	if !e.disableIP {
-		a = a.WithIP(e.LocalAddr())
+		if addr, ok := canonicalNATTraversalCandidate(e.LocalAddr()); ok {
+			a = a.WithIP(addr)
+		}
 		for _, addr := range e.externalNATLocked() {
 			a = a.WithIP(addr)
 		}

--- a/iroh/endpoint_addr_unspecified_test.go
+++ b/iroh/endpoint_addr_unspecified_test.go
@@ -1,0 +1,177 @@
+package iroh_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/tmc/go-iroh/iroh"
+	"github.com/tmc/go-iroh/key"
+)
+
+// TestEndpointAddrOmitsUnspecified checks that the address an endpoint
+// advertises never includes the unspecified bind address.
+//
+// Binding without WithBindAddr leaves the socket on [::]:port, which means
+// "every interface on this host" and is not something a peer can dial.
+func TestEndpointAddrOmitsUnspecified(t *testing.T) {
+	ctx := t.Context()
+
+	ep := bindForAddrTest(t, ctx)
+	if !ep.LocalAddr().Addr().IsUnspecified() {
+		t.Skipf("bound to %s, want an unspecified address for this test", ep.LocalAddr())
+	}
+
+	for _, addr := range ep.Addr().IPAddrs() {
+		if addr.Addr().IsUnspecified() {
+			t.Errorf("Addr() advertises the unspecified address %s; peers cannot dial it", addr)
+		}
+	}
+	for _, addr := range ep.WatchAddr().Current().IPAddrs() {
+		if addr.Addr().IsUnspecified() {
+			t.Errorf("WatchAddr() reports the unspecified address %s; peers cannot dial it", addr)
+		}
+	}
+}
+
+// TestConnectToAddrWithExternalAddr connects to an endpoint the way an
+// application does: by dialing what Endpoint.Addr reports, which is what an
+// endpoint ticket carries.
+//
+// An application that wants peers to reach it directly pins its interface
+// address with AddExternalAddr, which also offers that address as a QNT NAT
+// traversal candidate. When Addr also carried the unspecified bind address, the
+// resulting PATH_RESPONSE arrived from a source the connection did not
+// recognize and closed it with
+//
+//	PROTOCOL_VIOLATION (local): unexpected PATH_RESPONSE frame
+func TestConnectToAddrWithExternalAddr(t *testing.T) {
+	const alpn = "iroh/external-addr-test/1"
+
+	ctx := t.Context()
+	local := routableInterfaceAddr(t)
+
+	server := bindForAddrTest(t, ctx, alpn)
+	client := bindForAddrTest(t, ctx)
+
+	server.AddExternalAddr(netip.AddrPortFrom(local, server.LocalAddr().Port()))
+	client.AddExternalAddr(netip.AddrPortFrom(local, client.LocalAddr().Port()))
+
+	router, err := iroh.NewRouter(server, map[string]iroh.ProtocolHandler{
+		alpn: iroh.ProtocolHandlerFunc(echoEveryStream),
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewRouter: %v", err)
+	}
+	defer router.Shutdown(context.Background())
+
+	conn, err := client.Connect(ctx, server.Addr(), alpn)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	// NAT traversal probing runs shortly after the handshake, so exercise the
+	// connection across that window rather than only at the start.
+	for i := range 10 {
+		if err := echoRoundTrip(ctx, conn); err != nil {
+			t.Fatalf("round trip %d of 10: %v (connection: %v)", i+1, err, context.Cause(conn.Context()))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func echoEveryStream(ctx context.Context, conn *iroh.Conn) error {
+	for {
+		stream, err := conn.AcceptStream(ctx)
+		if err != nil {
+			return nil
+		}
+		go func() {
+			io.Copy(stream, stream)
+			stream.Close()
+		}()
+	}
+}
+
+func echoRoundTrip(ctx context.Context, conn *iroh.Conn) error {
+	stream, err := conn.OpenStreamSync(ctx)
+	if err != nil {
+		return fmt.Errorf("open stream: %w", err)
+	}
+	if _, err := stream.Write([]byte("ping")); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	// Close the send side so the echo handler's io.Copy finishes.
+	if err := stream.Close(); err != nil {
+		return fmt.Errorf("close write: %w", err)
+	}
+	if err := stream.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return err
+	}
+	got, err := io.ReadAll(stream)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if string(got) != "ping" {
+		return fmt.Errorf("echoed %q, want %q", got, "ping")
+	}
+	return nil
+}
+
+func bindForAddrTest(t *testing.T, ctx context.Context, alpns ...string) *iroh.Endpoint {
+	t.Helper()
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatalf("GenerateSecretKey: %v", err)
+	}
+	opts := []iroh.Option{iroh.WithSecretKey(sk)}
+	if len(alpns) > 0 {
+		opts = append(opts, iroh.WithALPNs(alpns...))
+	}
+	ep, err := iroh.Bind(ctx, opts...)
+	if err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	t.Cleanup(func() { ep.Shutdown(context.Background()) })
+	return ep
+}
+
+// routableInterfaceAddr returns an IPv4 address of one of this machine's
+// interfaces, skipping loopback and link-local, which are not usable NAT
+// traversal candidates.
+func routableInterfaceAddr(t *testing.T) netip.Addr {
+	t.Helper()
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatalf("net.Interfaces: %v", err)
+	}
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			ipNet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			ip, ok := netip.AddrFromSlice(ipNet.IP)
+			if !ok {
+				continue
+			}
+			if ip = ip.Unmap(); ip.Is4() && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() {
+				return ip
+			}
+		}
+	}
+	t.Skip("no routable interface address on this machine")
+	return netip.Addr{}
+}


### PR DESCRIPTION
`Endpoint.Addr` reports the address the socket is bound to, which is `[::]:port` unless the caller passed `WithBindAddr`. That address means "every interface on this host" — a peer that dials it reaches its own loopback. Because `Addr` is what `endpointticket.Encode` serializes, it goes out in every ticket.

`localNATTraversalCandidates` already states and enforces the rule:

> The default bind address is unspecified (`[::]:port`), which is not a usable candidate and must not be advertised.

This applies the same rule in `Addr` and `addrLocked`, reusing the existing `canonicalNATTraversalCandidate` helper.

### It also breaks connections

An application that wants peers to reach it directly on its LAN has to pin its interface address with `AddExternalAddr`, since nothing else puts a dialable address in the ticket. That address is then also offered as a QNT NAT traversal candidate. Combined with the unspecified address, the PATH_RESPONSE it draws arrives from a source the connection does not recognize and closes it:

```
PROTOCOL_VIOLATION (local): unexpected PATH_RESPONSE frame
```

I narrowed it to that exact combination:

| dialed address | pinned candidate | result |
| --- | --- | --- |
| interface address | no | pass |
| interface address | yes | pass |
| interface address + `[::]:port` | no | pass |
| interface address + `[::]:port` | **yes** | **fails** |

Only the combination fails — and it is the combination `Addr` produces on its own.

I hit this building a port-forwarding tool: two machines on the same LAN always connected through a relay, and pinning the LAN address to fix that cost 6 dropped connections in 8 attempts. Binding to a concrete address avoided both problems, which is what pointed at `Addr`.

### Tests

- `TestEndpointAddrOmitsUnspecified` — asserts `Addr()` and `WatchAddr()` never report an unspecified address. No network.
- `TestConnectToAddrWithExternalAddr` — pins an interface address, dials `server.Addr()` the way a ticket-based application does, and exercises the connection across the window when NAT traversal probing runs.

Both fail on `main` and pass with this change:

```
=== WITHOUT FIX ===
    endpoint_addr_unspecified_test.go:31: Addr() advertises the unspecified address [::]:38337; peers cannot dial it
    endpoint_addr_unspecified_test.go:36: WatchAddr() reports the unspecified address [::]:38337; peers cannot dial it
--- FAIL: TestEndpointAddrOmitsUnspecified (0.00s)
    endpoint_addr_unspecified_test.go:82: round trip 2 of 10: open stream: PROTOCOL_VIOLATION (local): unexpected PATH_RESPONSE frame
--- FAIL: TestConnectToAddrWithExternalAddr (0.20s)

=== WITH FIX ===
--- PASS: TestEndpointAddrOmitsUnspecified (0.00s)
--- PASS: TestConnectToAddrWithExternalAddr (2.02s)
```

`go test ./iroh/... ./internal/qng/... ./netaddr/... ./endpointticket/... ./relay/...` is otherwise unchanged.

`TestConnPaths` is flaky in this package independently of this change — `selected path count = 2, want 1`, with two entries for the same `[::1]` address. I measured 2/5 failures on `main` and 0/5 with this branch over full-package `-count=2` runs, so it looks pre-existing rather than related.

### Two things this does not fix

1. **An unmatched PATH_RESPONSE still closes the connection** even when it comes from an address the endpoint itself advertised as a NAT traversal candidate. This change stops go-iroh from producing the triggering combination, but the leniency gap in `qntAcceptsUnmatchedPathResponse` remains — forcing the wildcard into the dialed address still reproduces it. Happy to file that separately with the reproducer if useful; it is your state machine and I did not want to guess at the right fix.

2. **Nothing enumerates local interface addresses**, so an endpoint bound to the wildcard still has no direct address to advertise and same-LAN peers fall back to a relay. `Addr` is the bind address plus net-report results, and a net report only yields the public address a NAT presents. Rust iroh gathers local addresses; I would be glad to follow up with that if you want it.
