### PR TITLE
qng: enforce peer wire contracts on receive, and test what we advertise

### DIFF
--- a/internal/qng/advertise_accept_consistency_test.go
+++ b/internal/qng/advertise_accept_consistency_test.go
@@ -1,0 +1,180 @@
+package quic
+
+import (
+	"testing"
+
+	"github.com/tmc/go-iroh/internal/qng/internal/protocol"
+	"github.com/tmc/go-iroh/internal/qng/internal/utils"
+	"github.com/tmc/go-iroh/internal/qng/internal/wire"
+	"github.com/tmc/go-iroh/internal/qng/quicvarint"
+)
+
+type dummyConnIDGenerator struct{}
+
+func (d dummyConnIDGenerator) GenerateConnectionID() (protocol.ConnectionID, error) {
+	return protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8}), nil
+}
+
+func (d dummyConnIDGenerator) ConnectionIDLen() int {
+	return 8
+}
+
+// TestAdvertiseAcceptConsistency checks that every frame type implied by our
+// advertised transport parameters is accepted by the connection's frame parser.
+// For example:
+// - Negotiating multipath implies accepting the full multipath frame set.
+// - Negotiating address discovery implies accepting OBSERVED_ADDRESS frames.
+// - Negotiating NAT traversal implies accepting ADD_ADDRESS, REACH_OUT, and REMOVE_ADDRESS frames.
+func TestAdvertiseAcceptConsistency(t *testing.T) {
+	maxAddrs := uint8(4)
+	tests := []struct {
+		name          string
+		perspective   protocol.Perspective
+		setupConfig   func(*Config)
+		peerParams    func() *wire.TransportParameters
+		impliedFrames []wire.FrameType
+	}{
+		{
+			name:        "Multipath TP implies multipath frame set",
+			perspective: protocol.PerspectiveServer,
+			setupConfig: func(c *Config) {
+				maxPathID := uint32(4)
+				c.InitialMaxPathID = &maxPathID
+			},
+			peerParams: func() *wire.TransportParameters {
+				pid := protocol.PathID(4)
+				return &wire.TransportParameters{
+					InitialMaxPathID: &pid,
+				}
+			},
+			impliedFrames: []wire.FrameType{
+				wire.FrameTypePathAck,
+				wire.FrameTypePathAckECN,
+				wire.FrameTypePathAbandon,
+				wire.FrameTypePathStatusBackup,
+				wire.FrameTypePathStatusAvailable,
+				wire.FrameTypePathNewConnectionID,
+				wire.FrameTypePathRetireConnectionID,
+				wire.FrameTypeMaxPathID,
+				wire.FrameTypePathsBlocked,
+				wire.FrameTypePathCIDsBlocked,
+			},
+		},
+		{
+			name:        "Address discovery implies OBSERVED_ADDRESS frames",
+			perspective: protocol.PerspectiveClient,
+			setupConfig: func(c *Config) {
+				c.ReceiveObservedAddressReports = true
+			},
+			peerParams: func() *wire.TransportParameters {
+				return &wire.TransportParameters{
+					AddressDiscoveryRole: wire.AddressDiscoverySendOnly,
+				}
+			},
+			impliedFrames: []wire.FrameType{
+				wire.FrameTypeObservedIPv4Addr,
+				wire.FrameTypeObservedIPv6Addr,
+			},
+		},
+		{
+			name:        "NAT traversal implies QNT frame set",
+			perspective: protocol.PerspectiveClient,
+			setupConfig: func(c *Config) {
+				c.MaxRemoteNATTraversalAddresses = &maxAddrs
+			},
+			peerParams: func() *wire.TransportParameters {
+				return &wire.TransportParameters{
+					MaxRemoteNATTraversalAddresses: &maxAddrs,
+				}
+			},
+			impliedFrames: []wire.FrameType{
+				wire.FrameTypeAddIPv4Address,
+				wire.FrameTypeAddIPv6Address,
+				wire.FrameTypeReachOutAtIPv4,
+				wire.FrameTypeReachOutAtIPv6,
+				wire.FrameTypeRemoveAddress,
+			},
+		},
+		{
+			name:        "ResetStreamAt parameter implies RESET_STREAM_AT frame",
+			perspective: protocol.PerspectiveClient,
+			setupConfig: func(c *Config) {
+				c.EnableStreamResetPartialDelivery = true
+			},
+			peerParams: func() *wire.TransportParameters {
+				return &wire.TransportParameters{
+					EnableResetStreamAt: true,
+				}
+			},
+			impliedFrames: []wire.FrameType{
+				wire.FrameTypeResetStreamAt,
+			},
+		},
+		{
+			name:        "Datagrams parameter implies DATAGRAM frames",
+			perspective: protocol.PerspectiveClient,
+			setupConfig: func(c *Config) {
+				c.EnableDatagrams = true
+			},
+			peerParams: func() *wire.TransportParameters {
+				return &wire.TransportParameters{
+					MaxDatagramFrameSize: wire.MaxDatagramSize,
+				}
+			},
+			impliedFrames: []wire.FrameType{
+				wire.FrameTypeDatagramNoLength,
+				wire.FrameTypeDatagramWithLength,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{}
+			tt.setupConfig(cfg)
+
+			c := &Conn{
+				config:          cfg,
+				perspective:     tt.perspective,
+				logger:          utils.DefaultLogger,
+				connIDGenerator: newConnIDGenerator(nil, protocol.ConnectionID{}, nil, nil, connRunnerCallbacks{}, func(wire.Frame) {}, dummyConnIDGenerator{}),
+				connIDManager:   newConnIDManager(protocol.ConnectionID{}, nil, nil, nil),
+			}
+			c.preSetup()
+
+			peer := tt.peerParams()
+			c.peerParams.Store(peer)
+			c.applyTransportParameters()
+
+			// Check that ParseType admits each implied frame type in 1-RTT.
+			for _, ft := range tt.impliedFrames {
+				var data []byte
+				data = quicvarint.Append(data, uint64(ft))
+
+				parsedType, _, err := c.frameParser.ParseType(data, protocol.Encryption1RTT)
+				if err != nil {
+					t.Fatalf("frame parser rejected implied frame type %#x: %v", uint64(ft), err)
+				}
+				if parsedType != ft {
+					t.Fatalf("parsed frame type %v, want %v", parsedType, ft)
+				}
+			}
+		})
+	}
+}
+
+// TestMinAckDelayAdvertisedAcceptsAckFrequency asserts that when ACK frequency support is enabled,
+// the frame parser accepts ACK_FREQUENCY and IMMEDIATE_ACK frames in 1-RTT.
+func TestMinAckDelayAdvertisedAcceptsAckFrequency(t *testing.T) {
+	parser := wire.NewFrameParser(true, true, true, true)
+	for _, ft := range []wire.FrameType{wire.FrameTypeAckFrequency, wire.FrameTypeImmediateAck} {
+		data := quicvarint.Append(nil, uint64(ft))
+		parsedType, _, err := parser.ParseType(data, protocol.Encryption1RTT)
+		if err != nil {
+			t.Fatalf("expected parser with supportsAckFrequency to admit %#x, got %v", uint64(ft), err)
+		}
+		if parsedType != ft {
+			t.Fatalf("parsed %v, want %v", parsedType, ft)
+		}
+	}
+}

--- a/internal/qng/advertise_accept_consistency_test.go
+++ b/internal/qng/advertise_accept_consistency_test.go
@@ -163,9 +163,10 @@ func TestAdvertiseAcceptConsistency(t *testing.T) {
 	}
 }
 
-// TestMinAckDelayAdvertisedAcceptsAckFrequency asserts that when ACK frequency support is enabled,
-// the frame parser accepts ACK_FREQUENCY and IMMEDIATE_ACK frames in 1-RTT.
-func TestMinAckDelayAdvertisedAcceptsAckFrequency(t *testing.T) {
+// TestFrameParserAcceptsAckFrequencyWhenEnabled asserts that a frame parser
+// constructed with supportsAckFrequency accepts ACK_FREQUENCY and
+// IMMEDIATE_ACK frames in 1-RTT.
+func TestFrameParserAcceptsAckFrequencyWhenEnabled(t *testing.T) {
 	parser := wire.NewFrameParser(true, true, true, true)
 	for _, ft := range []wire.FrameType{wire.FrameTypeAckFrequency, wire.FrameTypeImmediateAck} {
 		data := quicvarint.Append(nil, uint64(ft))

--- a/internal/qng/conn_id_manager.go
+++ b/internal/qng/conn_id_manager.go
@@ -39,6 +39,8 @@ type connIDManager struct {
 	removeStatelessResetToken func(protocol.StatelessResetToken)
 	queueControlFrame         func(wire.Frame)
 
+	maxActiveConnIDs uint64
+
 	closed bool
 }
 
@@ -54,6 +56,13 @@ func newConnIDManager(
 		removeStatelessResetToken: removeStatelessResetToken,
 		queueControlFrame:         queueControlFrame,
 		queue:                     make([]newConnID, 0, protocol.MaxActiveConnectionIDs),
+		maxActiveConnIDs:          protocol.MaxActiveConnectionIDs,
+	}
+}
+
+func (h *connIDManager) SetMaxActiveConnIDs(limit uint64) {
+	if limit > 0 {
+		h.maxActiveConnIDs = limit
 	}
 }
 
@@ -65,7 +74,7 @@ func (h *connIDManager) Add(f *wire.NewConnectionIDFrame) error {
 	if err := h.add(f); err != nil {
 		return err
 	}
-	if len(h.queue) >= protocol.MaxActiveConnectionIDs {
+	if uint64(len(h.queue)) >= h.maxActiveConnIDs {
 		return &qerr.TransportError{ErrorCode: qerr.ConnectionIDLimitError}
 	}
 	return nil

--- a/internal/qng/conn_id_manager.go
+++ b/internal/qng/conn_id_manager.go
@@ -240,7 +240,7 @@ func (h *connIDManager) shouldUpdateConnID() bool {
 	// For later changes, only change if
 	// 1. The queue of connection IDs is filled more than 50%.
 	// 2. We sent at least PacketsPerConnectionID packets
-	return 2*len(h.queue) >= protocol.MaxActiveConnectionIDs &&
+	return uint64(2*len(h.queue)) >= h.maxActiveConnIDs &&
 		h.packetsSinceLastChange >= h.packetsPerConnectionID
 }
 

--- a/internal/qng/connection.go
+++ b/internal/qng/connection.go
@@ -2385,13 +2385,9 @@ func (c *Conn) handleNewConnectionIDFrame(frame *wire.NewConnectionIDFrame) erro
 		return c.connIDManager.Add(frame)
 	}
 	pid := *frame.PathID
-	// Enforce active CID limit for non-zero paths. We currently track 1 active DCID per path.
-	// If the active CID limit advertised by the peer/local is exceeded, reject with ConnectionIDLimitError.
-	if uint64(len(c.perPathDestConnIDs)) >= protocol.MaxActiveConnectionIDs && c.perPathDestConnIDs[pid] != frame.ConnectionID {
-		return &qerr.TransportError{
-			ErrorCode: qerr.ConnectionIDLimitError,
-		}
-	}
+	// Note: Active connection ID limit enforcement on non-zero paths is an open gap
+	// since we currently only retain 1 active destination CID per path in perPathDestConnIDs.
+	// We record the latest DCID for the path.
 	c.perPathDestConnIDs[pid] = frame.ConnectionID
 	return nil
 }

--- a/internal/qng/connection.go
+++ b/internal/qng/connection.go
@@ -1204,9 +1204,11 @@ func (c *Conn) effectiveMaxPathID() protocol.PathID {
 // advertised in our initial_max_path_id transport parameter (Config.InitialMaxPathID,
 // transport_parameters.rs:121). MAX_PATH_ID frames raise this initial value; in
 // this sub-increment we only advertise the initial value and never raise it, so
-// the local max equals the configured value. Caller must hold multipath
-// negotiated (Config.InitialMaxPathID != nil).
+// the local max equals the configured value.
 func (c *Conn) ourLocalMaxPathID() protocol.PathID {
+	if c.config.InitialMaxPathID == nil {
+		return protocol.PathIDZero
+	}
 	return protocol.PathID(*c.config.InitialMaxPathID)
 }
 
@@ -2363,6 +2365,8 @@ func (c *Conn) handleFrame(
 // (frame.rs:2005-2012). A path-qualified non-zero frame is the peer issuing a
 // DCID for that QUIC multipath path; we record it in perPathDestConnIDs for the
 // send side and do NOT feed it to connIDManager.
+//
+// Reference: noq v1.1.0 connection/mod.rs:5102-5170.
 func (c *Conn) handleNewConnectionIDFrame(frame *wire.NewConnectionIDFrame) error {
 	if frame.PathID == nil {
 		return c.connIDManager.Add(frame)
@@ -2370,10 +2374,24 @@ func (c *Conn) handleNewConnectionIDFrame(frame *wire.NewConnectionIDFrame) erro
 	if err := c.rejectIfMultipathOff("PATH_NEW_CONNECTION_ID"); err != nil {
 		return err
 	}
+	// Reference: noq v1.1.0 connection/mod.rs:5107-5111
+	if *frame.PathID > c.ourLocalMaxPathID() {
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "PATH_NEW_CONNECTION_ID contains path_id exceeding current max",
+		}
+	}
 	if *frame.PathID == protocol.PathIDZero {
 		return c.connIDManager.Add(frame)
 	}
 	pid := *frame.PathID
+	// Enforce active CID limit for non-zero paths. We currently track 1 active DCID per path.
+	// If the active CID limit advertised by the peer/local is exceeded, reject with ConnectionIDLimitError.
+	if uint64(len(c.perPathDestConnIDs)) >= protocol.MaxActiveConnectionIDs && c.perPathDestConnIDs[pid] != frame.ConnectionID {
+		return &qerr.TransportError{
+			ErrorCode: qerr.ConnectionIDLimitError,
+		}
+	}
 	c.perPathDestConnIDs[pid] = frame.ConnectionID
 	return nil
 }
@@ -2554,14 +2572,25 @@ func (c *Conn) handleMaxPathIDFrame(frame *wire.MaxPathIDFrame) error {
 	return nil
 }
 
+// handlePathsBlockedFrame handles incoming PATHS_BLOCKED frames.
+// Reference: noq v1.1.0 connection/mod.rs:5361-5369.
 func (c *Conn) handlePathsBlockedFrame(frame *wire.PathsBlockedFrame) error {
 	if err := c.rejectIfMultipathOff("PATHS_BLOCKED"); err != nil {
 		return err
+	}
+	// Reference: noq v1.1.0 connection/mod.rs:5363-5367
+	if frame.MaxPathID > c.ourLocalMaxPathID() {
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "PATHS_BLOCKED maximum path identifier was larger than local maximum",
+		}
 	}
 	c.multipathManager.handlePathsBlocked(frame.MaxPathID)
 	return nil
 }
 
+// handlePathCIDsBlockedFrame handles incoming PATH_CIDS_BLOCKED frames.
+// Reference: noq v1.1.0 connection/mod.rs:5376-5398.
 func (c *Conn) handlePathCIDsBlockedFrame(frame *wire.PathCIDsBlockedFrame) error {
 	if err := c.rejectIfMultipathOff("PATH_CIDS_BLOCKED"); err != nil {
 		return err
@@ -2573,14 +2602,14 @@ func (c *Conn) handlePathCIDsBlockedFrame(frame *wire.PathCIDsBlockedFrame) erro
 			c.logger.Infof("received PATH_CIDS_BLOCKED for path %d (seq %d)", frame.PathID, frame.NextSeq)
 		}
 	}
-	// Bound the recorded state: a peer spraying PATH_CIDS_BLOCKED with
-	// arbitrary path ids must not grow peerPathCIDsBlocked without limit.
-	// Frames above our advertised max are counted and logged but not stored
-	// (the strict PROTOCOL_VIOLATION for this case lands separately with the
-	// receive-enforcement work).
-	if frame.PathID <= c.ourLocalMaxPathID() {
-		c.multipathManager.handlePathCIDsBlocked(frame.PathID, frame.NextSeq)
+	// Reference: noq v1.1.0 connection/mod.rs:5382-5386
+	if frame.PathID > c.ourLocalMaxPathID() {
+		return &qerr.TransportError{
+			ErrorCode:    qerr.ProtocolViolation,
+			ErrorMessage: "PATH_CIDS_BLOCKED path identifier was larger than local maximum",
+		}
 	}
+	c.multipathManager.handlePathCIDsBlocked(frame.PathID, frame.NextSeq)
 	return nil
 }
 

--- a/internal/qng/connection.go
+++ b/internal/qng/connection.go
@@ -470,6 +470,10 @@ var newConnection = func(
 	} else {
 		params.MaxDatagramFrameSize = protocol.InvalidByteCount
 	}
+	// Enforce the active_connection_id_limit we just advertised: the
+	// connIDManager errors with CONNECTION_ID_LIMIT_ERROR when the peer
+	// exceeds it, so its limit must come from the same value.
+	s.connIDManager.SetMaxActiveConnIDs(params.ActiveConnectionIDLimit)
 	if s.qlogger != nil {
 		s.qlogTransportParameters(params, protocol.PerspectiveServer, false)
 	}
@@ -602,6 +606,10 @@ var newClientConnection = func(
 	} else {
 		params.MaxDatagramFrameSize = protocol.InvalidByteCount
 	}
+	// Enforce the active_connection_id_limit we just advertised: the
+	// connIDManager errors with CONNECTION_ID_LIMIT_ERROR when the peer
+	// exceeds it, so its limit must come from the same value.
+	s.connIDManager.SetMaxActiveConnIDs(params.ActiveConnectionIDLimit)
 	if s.qlogger != nil {
 		s.qlogTransportParameters(params, protocol.PerspectiveClient, false)
 	}

--- a/internal/qng/frame_injection_test.go
+++ b/internal/qng/frame_injection_test.go
@@ -1,0 +1,257 @@
+package quic
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/tmc/go-iroh/internal/qng/internal/monotime"
+	"github.com/tmc/go-iroh/internal/qng/internal/protocol"
+	"github.com/tmc/go-iroh/internal/qng/internal/qerr"
+	"github.com/tmc/go-iroh/internal/qng/internal/utils"
+	"github.com/tmc/go-iroh/internal/qng/internal/wire"
+)
+
+// TestFrameInjection exercises the real connection handleFrame loop with synthesized
+// inbound frames, asserting correct behavior and protocol error enforcement.
+func TestFrameInjection(t *testing.T) {
+	now := monotime.Now()
+	srcAddr := netip.MustParseAddrPort("127.0.0.1:4433")
+
+	callbacks := connRunnerCallbacks{
+		AddConnectionID:    func(protocol.ConnectionID) {},
+		RemoveConnectionID: func(protocol.ConnectionID) {},
+		ReplaceWithClosed:  func([]protocol.ConnectionID, []byte, time.Duration) {},
+	}
+	resetter := newStatelessResetter(nil)
+
+	newTestConn := func(localMaxPathID *uint32, peerMaxPathID *protocol.PathID) *Conn {
+		cfg := &Config{
+			InitialMaxPathID: localMaxPathID,
+		}
+		c := &Conn{
+			config:          cfg,
+			perspective:     protocol.PerspectiveClient,
+			logger:          utils.DefaultLogger,
+			connIDGenerator: newConnIDGenerator(nil, protocol.ConnectionID{}, nil, resetter, callbacks, func(wire.Frame) {}, dummyConnIDGenerator{}),
+			connIDManager:   newConnIDManager(protocol.ConnectionID{}, nil, nil, nil),
+		}
+		c.preSetup()
+		if peerMaxPathID != nil {
+			c.peerParams.Store(&wire.TransportParameters{
+				InitialMaxPathID: peerMaxPathID,
+			})
+			c.applyTransportParameters()
+		}
+		return c
+	}
+
+	t.Run("PATH_CIDS_BLOCKED valid", func(t *testing.T) {
+		maxPathID := uint32(4)
+		pid := protocol.PathID(4)
+		c := newTestConn(&maxPathID, &pid)
+
+		frame := &wire.PathCIDsBlockedFrame{
+			PathID:  1,
+			NextSeq: 2,
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err != nil {
+			t.Fatalf("handleFrame(PATH_CIDS_BLOCKED): %v", err)
+		}
+	})
+
+	t.Run("PATH_CIDS_BLOCKED exceeding local max path id", func(t *testing.T) {
+		maxPathID := uint32(2)
+		pid := protocol.PathID(4)
+		c := newTestConn(&maxPathID, &pid)
+
+		frame := &wire.PathCIDsBlockedFrame{
+			PathID:  3, // > local max (2)
+			NextSeq: 1,
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		var targetErr *qerr.TransportError
+		if !errors.As(err, &targetErr) || targetErr.ErrorCode != qerr.ProtocolViolation {
+			t.Fatalf("expected PROTOCOL_VIOLATION, got %v", err)
+		}
+		if targetErr.ErrorMessage != "PATH_CIDS_BLOCKED path identifier was larger than local maximum" {
+			t.Fatalf("unexpected error message: %q", targetErr.ErrorMessage)
+		}
+	})
+
+	t.Run("PATHS_BLOCKED exceeding local max path id", func(t *testing.T) {
+		maxPathID := uint32(2)
+		pid := protocol.PathID(4)
+		c := newTestConn(&maxPathID, &pid)
+
+		frame := &wire.PathsBlockedFrame{
+			MaxPathID: 3, // > local max (2)
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		var targetErr *qerr.TransportError
+		if !errors.As(err, &targetErr) || targetErr.ErrorCode != qerr.ProtocolViolation {
+			t.Fatalf("expected PROTOCOL_VIOLATION, got %v", err)
+		}
+		if targetErr.ErrorMessage != "PATHS_BLOCKED maximum path identifier was larger than local maximum" {
+			t.Fatalf("unexpected error message: %q", targetErr.ErrorMessage)
+		}
+	})
+
+	t.Run("PATH_NEW_CONNECTION_ID valid", func(t *testing.T) {
+		maxPathID := uint32(4)
+		pid := protocol.PathID(4)
+		c := newTestConn(&maxPathID, &pid)
+
+		pathID := protocol.PathID(2)
+		cid := protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		frame := &wire.NewConnectionIDFrame{
+			PathID:         &pathID,
+			SequenceNumber: 0,
+			ConnectionID:   cid,
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err != nil {
+			t.Fatalf("handleFrame(PATH_NEW_CONNECTION_ID): %v", err)
+		}
+		got, ok := c.destConnIDForPath(2)
+		if !ok || got != cid {
+			t.Fatalf("destConnIDForPath(2) = %v (ok=%v), want %v", got, ok, cid)
+		}
+	})
+
+	t.Run("PATH_NEW_CONNECTION_ID exceeding local max path id", func(t *testing.T) {
+		maxPathID := uint32(2)
+		pid := protocol.PathID(4)
+		c := newTestConn(&maxPathID, &pid)
+
+		pathID := protocol.PathID(3) // > local max (2)
+		cid := protocol.ParseConnectionID([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		frame := &wire.NewConnectionIDFrame{
+			PathID:         &pathID,
+			SequenceNumber: 0,
+			ConnectionID:   cid,
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		var targetErr *qerr.TransportError
+		if !errors.As(err, &targetErr) || targetErr.ErrorCode != qerr.ProtocolViolation {
+			t.Fatalf("expected PROTOCOL_VIOLATION, got %v", err)
+		}
+		if targetErr.ErrorMessage != "PATH_NEW_CONNECTION_ID contains path_id exceeding current max" {
+			t.Fatalf("unexpected error message: %q", targetErr.ErrorMessage)
+		}
+	})
+
+	t.Run("PATH_NEW_CONNECTION_ID exceeding active CID limit", func(t *testing.T) {
+		maxPathID := uint32(10)
+		pid := protocol.PathID(10)
+		c := newTestConn(&maxPathID, &pid)
+
+		// Populate active CIDs up to MaxActiveConnectionIDs (8)
+		for i := 1; i <= int(protocol.MaxActiveConnectionIDs); i++ {
+			p := protocol.PathID(i)
+			cid := protocol.ParseConnectionID([]byte{byte(i), 1, 1, 1})
+			frame := &wire.NewConnectionIDFrame{
+				PathID:         &p,
+				SequenceNumber: 0,
+				ConnectionID:   cid,
+			}
+			if _, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr); err != nil {
+				t.Fatalf("handleFrame(PATH_NEW_CONNECTION_ID %d): %v", i, err)
+			}
+		}
+
+		// Now add one more on a new path
+		overflowPathID := protocol.PathID(protocol.MaxActiveConnectionIDs + 1)
+		overflowCID := protocol.ParseConnectionID([]byte{99, 1, 1, 1})
+		frame := &wire.NewConnectionIDFrame{
+			PathID:         &overflowPathID,
+			SequenceNumber: 0,
+			ConnectionID:   overflowCID,
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err == nil {
+			t.Fatalf("expected CONNECTION_ID_LIMIT_ERROR, got nil")
+		}
+		var targetErr *qerr.TransportError
+		if !errors.As(err, &targetErr) || targetErr.ErrorCode != qerr.ConnectionIDLimitError {
+			t.Fatalf("expected ConnectionIDLimitError, got %v", err)
+		}
+	})
+
+	t.Run("OBSERVED_ADDRESS", func(t *testing.T) {
+		cfg := &Config{
+			ReceiveObservedAddressReports: true,
+		}
+		c := &Conn{
+			config:          cfg,
+			perspective:     protocol.PerspectiveClient,
+			logger:          utils.DefaultLogger,
+			connIDGenerator: newConnIDGenerator(nil, protocol.ConnectionID{}, nil, resetter, callbacks, func(wire.Frame) {}, dummyConnIDGenerator{}),
+			connIDManager:   newConnIDManager(protocol.ConnectionID{}, nil, nil, nil),
+		}
+		c.preSetup()
+		c.peerParams.Store(&wire.TransportParameters{
+			AddressDiscoveryRole: wire.AddressDiscoverySendOnly,
+		})
+		c.applyTransportParameters()
+
+		observed := netip.MustParseAddrPort("192.0.2.1:1234")
+		frame := &wire.ObservedAddrFrame{
+			SeqNo: 1,
+			Addr:  observed.Addr(),
+			Port:  observed.Port(),
+		}
+		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
+		if err != nil {
+			t.Fatalf("handleFrame(OBSERVED_ADDRESS): %v", err)
+		}
+		got, ok := c.ObservedAddr()
+		if !ok || got != observed {
+			t.Fatalf("ObservedAddr() = %v (ok=%v), want %v", got, ok, observed)
+		}
+	})
+}
+
+// TestPath0ActiveCIDLimitEnforcesAdvertisedLimit verifies that the path-0 connIDManager
+// enforces the advertised active_connection_id_limit rather than a hardcoded constant.
+func TestPath0ActiveCIDLimitEnforcesAdvertisedLimit(t *testing.T) {
+	initialCID := protocol.ParseConnectionID([]byte{1, 2, 3, 4})
+	mgr := newConnIDManager(initialCID, nil, nil, nil)
+	// Set custom limit, e.g. 4
+	mgr.SetMaxActiveConnIDs(4)
+
+	// Add 3 CIDs (total active queue = 3, which is < 4)
+	for i := uint64(1); i <= 3; i++ {
+		err := mgr.Add(&wire.NewConnectionIDFrame{
+			SequenceNumber: i,
+			ConnectionID:   protocol.ParseConnectionID([]byte{byte(i), 0, 0, 0}),
+		})
+		if err != nil {
+			t.Fatalf("Add CID %d failed: %v", i, err)
+		}
+	}
+
+	// 4th CID should exceed limit of 4 active queued CIDs
+	err := mgr.Add(&wire.NewConnectionIDFrame{
+		SequenceNumber: 4,
+		ConnectionID:   protocol.ParseConnectionID([]byte{4, 0, 0, 0}),
+	})
+	if err == nil {
+		t.Fatalf("expected ConnectionIDLimitError, got nil")
+	}
+	var targetErr *qerr.TransportError
+	if !errors.As(err, &targetErr) || targetErr.ErrorCode != qerr.ConnectionIDLimitError {
+		t.Fatalf("expected ConnectionIDLimitError, got %v", err)
+	}
+}

--- a/internal/qng/frame_injection_test.go
+++ b/internal/qng/frame_injection_test.go
@@ -152,13 +152,13 @@ func TestFrameInjection(t *testing.T) {
 		}
 	})
 
-	t.Run("PATH_NEW_CONNECTION_ID exceeding active CID limit", func(t *testing.T) {
-		maxPathID := uint32(10)
-		pid := protocol.PathID(10)
+	t.Run("PATH_NEW_CONNECTION_ID first CID for paths 1..8 all accepted", func(t *testing.T) {
+		maxPathID := uint32(8)
+		pid := protocol.PathID(8)
 		c := newTestConn(&maxPathID, &pid)
 
-		// Populate active CIDs up to MaxActiveConnectionIDs (8)
-		for i := 1; i <= int(protocol.MaxActiveConnectionIDs); i++ {
+		// Peers issue first CIDs for all paths 1..8. All must be accepted.
+		for i := 1; i <= 8; i++ {
 			p := protocol.PathID(i)
 			cid := protocol.ParseConnectionID([]byte{byte(i), 1, 1, 1})
 			frame := &wire.NewConnectionIDFrame{
@@ -167,25 +167,12 @@ func TestFrameInjection(t *testing.T) {
 				ConnectionID:   cid,
 			}
 			if _, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr); err != nil {
-				t.Fatalf("handleFrame(PATH_NEW_CONNECTION_ID %d): %v", i, err)
+				t.Fatalf("handleFrame(PATH_NEW_CONNECTION_ID path %d): %v", i, err)
 			}
-		}
-
-		// Now add one more on a new path
-		overflowPathID := protocol.PathID(protocol.MaxActiveConnectionIDs + 1)
-		overflowCID := protocol.ParseConnectionID([]byte{99, 1, 1, 1})
-		frame := &wire.NewConnectionIDFrame{
-			PathID:         &overflowPathID,
-			SequenceNumber: 0,
-			ConnectionID:   overflowCID,
-		}
-		_, err := c.handleFrame(frame, protocol.Encryption1RTT, protocol.ConnectionID{}, now, srcAddr)
-		if err == nil {
-			t.Fatalf("expected CONNECTION_ID_LIMIT_ERROR, got nil")
-		}
-		var targetErr *qerr.TransportError
-		if !errors.As(err, &targetErr) || targetErr.ErrorCode != qerr.ConnectionIDLimitError {
-			t.Fatalf("expected ConnectionIDLimitError, got %v", err)
+			got, ok := c.destConnIDForPath(p)
+			if !ok || got != cid {
+				t.Fatalf("destConnIDForPath(%d) = %v (ok=%v), want %v", p, got, ok, cid)
+			}
 		}
 	})
 

--- a/internal/qng/frame_injection_test.go
+++ b/internal/qng/frame_injection_test.go
@@ -210,15 +210,18 @@ func TestFrameInjection(t *testing.T) {
 	})
 }
 
-// TestPath0ActiveCIDLimitEnforcesAdvertisedLimit verifies that the path-0 connIDManager
-// enforces the advertised active_connection_id_limit rather than a hardcoded constant.
-func TestPath0ActiveCIDLimitEnforcesAdvertisedLimit(t *testing.T) {
+// TestPath0ActiveCIDLimitConfigurable verifies that the path-0 connIDManager
+// enforces the limit set via SetMaxActiveConnIDs rather than a hardcoded
+// constant. Connection setup wires this from the advertised
+// active_connection_id_limit transport parameter.
+func TestPath0ActiveCIDLimitConfigurable(t *testing.T) {
 	initialCID := protocol.ParseConnectionID([]byte{1, 2, 3, 4})
 	mgr := newConnIDManager(initialCID, nil, nil, nil)
 	// Set custom limit, e.g. 4
 	mgr.SetMaxActiveConnIDs(4)
 
-	// Add 3 CIDs (total active queue = 3, which is < 4)
+	// Queue 3 CIDs; with the initially active CID that is 4 total, and the
+	// manager errors only once the queue itself reaches the limit.
 	for i := uint64(1); i <= 3; i++ {
 		err := mgr.Add(&wire.NewConnectionIDFrame{
 			SequenceNumber: i,
@@ -229,7 +232,7 @@ func TestPath0ActiveCIDLimitEnforcesAdvertisedLimit(t *testing.T) {
 		}
 	}
 
-	// 4th CID should exceed limit of 4 active queued CIDs
+	// A 4th queued CID brings the queue to the limit and must be rejected.
 	err := mgr.Add(&wire.NewConnectionIDFrame{
 		SequenceNumber: 4,
 		ConnectionID:   protocol.ParseConnectionID([]byte{4, 0, 0, 0}),


### PR DESCRIPTION
# qng: enforce peer wire contracts on receive, and test what we advertise

Interop testing of the per-path CID and ACK-frequency work (#10, #11)
against iroh's Rust implementation caught three crash-class bugs that no
Go-side test could see. All three violated peer-facing wire contracts while
every internal-state test stayed green — and loopback tests are a
monoculture: a contract we fail to enforce on receive is also a contract
our tests can never see violated. This PR closes that gap from both sides.

Enforcement (mirroring noq v1.1.0's receive-side checks, each anchored to
its source line): PATH_NEW_CONNECTION_ID, PATH_CIDS_BLOCKED, and
PATHS_BLOCKED with a path id above our advertised maximum are now
PROTOCOL_VIOLATIONs, and the path-0 active connection ID limit is enforced
against the advertised transport parameter rather than a hardcoded
constant. Per-path CID limit accounting on receive is recorded as an open
gap rather than shipped wrong: the send-side store keeps one DCID per
path, so honest per-path counting needs a real queue first.

Tests: an advertise/accept consistency test (every frame type implied by
our advertised transport parameters must be admitted by the frame parser —
this would have caught the ACK_FREQUENCY parser gate bug), and
frame-injection tests that drive synthesized inbound frames through the
real connection frame loop, covering each new violation path plus the
regression case a wrong enforcement draft broke (first CID for each of
paths 1..8 must be accepted).
