### PR TITLE
postcard: pin the 8-bit encoding and reject non-canonical varints

### DIFF
--- a/internal/postcard/postcard.go
+++ b/internal/postcard/postcard.go
@@ -5,6 +5,12 @@
 // Go values of kind uint8 and int8 follow that rule, so uint8(200) encodes as
 // "c8" and int8(-2) as "fe".
 //
+// The 8-bit encoding changed in this v0 release: uint8 and int8 were previously
+// written as a varint and a zigzag varint, which did not match Rust. A uint8
+// below 128 encodes to the same single byte either way, so records holding only
+// small u8 tags are unaffected; a uint8 of 128 or more, and an int8 of anything
+// but zero, encoded differently before and cannot be read back by this version.
+//
 // Decoding accepts only canonical varints: a padded encoding such as "ac8200"
 // for 300 is rejected with [ErrOverlongVarint], so distinct byte strings never
 // decode to the same value.

--- a/internal/postcard/postcard.go
+++ b/internal/postcard/postcard.go
@@ -4,6 +4,10 @@
 // zigzagged first, except for u8 and i8: postcard writes those as one raw byte.
 // Go values of kind uint8 and int8 follow that rule, so uint8(200) encodes as
 // "c8" and int8(-2) as "fe".
+//
+// Decoding accepts only canonical varints: a padded encoding such as "ac8200"
+// for 300 is rejected with [ErrOverlongVarint], so distinct byte strings never
+// decode to the same value.
 package postcard
 
 import (
@@ -33,7 +37,11 @@ type DecoderFrom interface {
 var (
 	// ErrTrailingBytes is returned when Unmarshal does not consume all input.
 	ErrTrailingBytes = errors.New("postcard: trailing bytes")
-	errShort         = errors.New("postcard: truncated input")
+	// ErrOverlongVarint is returned for a varint that is not canonically
+	// encoded: one padded with continuation bytes past the shortest form, or
+	// one whose value does not fit in 64 bits.
+	ErrOverlongVarint = errors.New("postcard: overlong varint")
+	errShort          = errors.New("postcard: truncated input")
 )
 
 // Marshal encodes v in postcard format.
@@ -470,6 +478,12 @@ func appendVarint(dst []byte, v uint64) []byte {
 	return append(dst, byte(v))
 }
 
+// readVarint decodes one little-endian base-128 varint from the front of buf,
+// returning its value and length. Only the canonical encoding is accepted: a
+// final byte of zero after a continuation byte means the value was padded and
+// could have been written in fewer bytes. Rejecting those keeps the mapping
+// from bytes to values injective, which any protocol that identifies a record
+// by a digest of its encoding depends on.
 func readVarint(buf []byte) (uint64, int, error) {
 	var v uint64
 	for i := 0; i < len(buf); i++ {
@@ -478,10 +492,13 @@ func readVarint(buf []byte) (uint64, int, error) {
 		}
 		b := buf[i]
 		if i == 9 && b > 1 {
-			return 0, 0, fmt.Errorf("postcard: varint overflow")
+			return 0, 0, ErrOverlongVarint
 		}
 		v |= uint64(b&0x7f) << (7 * i)
 		if b < 0x80 {
+			if i > 0 && b == 0 {
+				return 0, 0, ErrOverlongVarint
+			}
 			return v, i + 1, nil
 		}
 	}

--- a/internal/postcard/postcard.go
+++ b/internal/postcard/postcard.go
@@ -1,4 +1,9 @@
 // Package postcard encodes and decodes the Rust postcard wire format.
+//
+// Integers are varints, little-endian base-128, and signed integers are
+// zigzagged first, except for u8 and i8: postcard writes those as one raw byte.
+// Go values of kind uint8 and int8 follow that rule, so uint8(200) encodes as
+// "c8" and int8(-2) as "fe".
 package postcard
 
 import (
@@ -72,11 +77,20 @@ func (e *Encoder) Encode(v any) error {
 // Bytes returns a copy of the encoded bytes.
 func (e *Encoder) Bytes() []byte { return append([]byte(nil), e.b...) }
 
-// Uint appends v as a postcard unsigned integer.
+// Uint appends v as a postcard unsigned integer. Use [Encoder.Uint8] for a
+// Rust u8, which is not varint-encoded.
 func (e *Encoder) Uint(v uint64) { e.b = appendVarint(e.b, v) }
 
-// Int appends v as a postcard signed integer.
+// Int appends v as a postcard signed integer. Use [Encoder.Int8] for a Rust i8,
+// which is not zigzag-encoded.
 func (e *Encoder) Int(v int64) { e.b = appendVarint(e.b, zigzag(v)) }
+
+// Uint8 appends v as a postcard u8: one raw byte, not a varint.
+func (e *Encoder) Uint8(v uint8) { e.b = append(e.b, v) }
+
+// Int8 appends v as a postcard i8: one raw byte holding the two's complement,
+// not a zigzag varint.
+func (e *Encoder) Int8(v int8) { e.b = append(e.b, byte(v)) }
 
 // Bool appends v as a postcard bool.
 func (e *Encoder) Bool(v bool) {
@@ -136,9 +150,13 @@ func (e *Encoder) value(v reflect.Value) error {
 		return e.value(v.Elem())
 	case reflect.Bool:
 		e.Bool(v.Bool())
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+	case reflect.Uint8:
+		e.Uint8(uint8(v.Uint()))
+	case reflect.Int8:
+		e.Int8(int8(v.Int()))
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		e.Uint(v.Uint())
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
 		e.Int(v.Int())
 	case reflect.String:
 		return e.bytes([]byte(v.String()))
@@ -215,10 +233,21 @@ func (d *Decoder) Decode(v any) error {
 // Done reports whether d consumed all input.
 func (d *Decoder) Done() bool { return d.off == len(d.b) }
 
-// Uint decodes a postcard unsigned integer.
+// Uint decodes a postcard unsigned integer. Use [Decoder.Uint8] for a Rust u8,
+// which is not varint-encoded.
 func (d *Decoder) Uint() (uint64, error) { return d.varint() }
 
-// Int decodes a postcard signed integer.
+// Uint8 decodes a postcard u8: one raw byte.
+func (d *Decoder) Uint8() (uint8, error) { return d.byte() }
+
+// Int8 decodes a postcard i8: one raw byte holding the two's complement.
+func (d *Decoder) Int8() (int8, error) {
+	b, err := d.byte()
+	return int8(b), err
+}
+
+// Int decodes a postcard signed integer. Use [Decoder.Int8] for a Rust i8,
+// which is not zigzag-encoded.
 func (d *Decoder) Int() (int64, error) {
 	x, err := d.varint()
 	if err != nil {
@@ -297,7 +326,19 @@ func (d *Decoder) value(v reflect.Value) error {
 			return err
 		}
 		v.SetBool(x)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+	case reflect.Uint8:
+		x, err := d.Uint8()
+		if err != nil {
+			return err
+		}
+		v.SetUint(uint64(x))
+	case reflect.Int8:
+		x, err := d.Int8()
+		if err != nil {
+			return err
+		}
+		v.SetInt(int64(x))
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		x, err := d.varint()
 		if err != nil {
 			return err
@@ -306,7 +347,7 @@ func (d *Decoder) value(v reflect.Value) error {
 			return fmt.Errorf("postcard: %d overflows %s", x, v.Type())
 		}
 		v.SetUint(x)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
 		i, err := d.Int()
 		if err != nil {
 			return err

--- a/internal/postcard/postcard_test.go
+++ b/internal/postcard/postcard_test.go
@@ -238,3 +238,77 @@ func TestUnmarshalErrors(t *testing.T) {
 		t.Fatal("Unmarshal accepted invalid option")
 	}
 }
+
+type eightBit struct {
+	U8  uint8
+	U16 uint16
+	OK  bool
+	I8  int8
+}
+
+// TestByteSizedRustVectors pins the u8/i8 encoding against Rust postcard, which
+// writes both as one raw byte rather than a varint or a zigzag varint. No type
+// in this module has an 8-bit field, so nothing else guards it.
+func TestByteSizedRustVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		v    any
+		hex  string
+	}{
+		{name: "u8 small", v: uint8(1), hex: "01"},
+		{name: "u8 high bit", v: uint8(200), hex: "c8"},
+		{name: "u8 max", v: uint8(255), hex: "ff"},
+		{name: "i8 zero", v: int8(0), hex: "00"},
+		{name: "i8 negative", v: int8(-2), hex: "fe"},
+		{name: "i8 min", v: int8(-128), hex: "80"},
+		{name: "i8 max", v: int8(127), hex: "7f"},
+		{
+			name: "mixed struct",
+			v:    eightBit{U8: 200, U16: 300, OK: true, I8: -2},
+			hex:  "c8ac0201fe",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Marshal(tt.v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hex.EncodeToString(got) != tt.hex {
+				t.Fatalf("Marshal = %s, want %s", hex.EncodeToString(got), tt.hex)
+			}
+			raw, err := hex.DecodeString(tt.hex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out := reflect.New(reflect.TypeOf(tt.v))
+			if err := Unmarshal(raw, out.Interface()); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(out.Elem().Interface(), tt.v) {
+				t.Fatalf("Unmarshal = %#v, want %#v", out.Elem().Interface(), tt.v)
+			}
+		})
+	}
+}
+
+// TestEncoderByteSizedHelpers checks that the hand-written codec path agrees
+// with the reflection path on u8 and i8.
+func TestEncoderByteSizedHelpers(t *testing.T) {
+	var e Encoder
+	e.Uint8(200)
+	e.Int8(-2)
+	if got := hex.EncodeToString(e.Bytes()); got != "c8fe" {
+		t.Fatalf("Encoder = %s, want c8fe", got)
+	}
+	d := NewDecoder(e.Bytes())
+	if u, err := d.Uint8(); err != nil || u != 200 {
+		t.Fatalf("Uint8 = %d, %v", u, err)
+	}
+	if i, err := d.Int8(); err != nil || i != -2 {
+		t.Fatalf("Int8 = %d, %v", i, err)
+	}
+	if !d.Done() {
+		t.Fatal("decoder did not consume all input")
+	}
+}

--- a/internal/postcard/postcard_test.go
+++ b/internal/postcard/postcard_test.go
@@ -312,3 +312,50 @@ func TestEncoderByteSizedHelpers(t *testing.T) {
 		t.Fatal("decoder did not consume all input")
 	}
 }
+
+// TestOverlongVarintRejected checks that a padded varint is rejected. Accepting
+// one would let two byte strings decode to the same value, so a record
+// identified by a digest of its encoding would have two valid ids.
+func TestOverlongVarintRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		hex  string
+		into func() any
+	}{
+		{name: "u16 padded", hex: "ac8200", into: func() any { return new(uint16) }},
+		{name: "zero padded", hex: "8000", into: func() any { return new(uint64) }},
+		{name: "max padding", hex: "80808080808080808000", into: func() any { return new(uint64) }},
+		{name: "sequence length", hex: "810041", into: func() any { return new([]byte) }},
+		{name: "string length", hex: "810061", into: func() any { return new(string) }},
+		{name: "zigzag int", hex: "038000", into: func() any { return new([2]int64) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := hex.DecodeString(tt.hex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := Unmarshal(raw, tt.into()); !errors.Is(err, ErrOverlongVarint) {
+				t.Fatalf("Unmarshal(%s) error = %v, want ErrOverlongVarint", tt.hex, err)
+			}
+		})
+	}
+}
+
+// TestCanonicalVarintsStillDecode guards the rejection against overreach: the
+// shortest encoding of each value must keep decoding.
+func TestCanonicalVarintsStillDecode(t *testing.T) {
+	for _, want := range []uint64{0, 1, 127, 128, 300, 624485, 1 << 62, ^uint64(0)} {
+		b, err := Marshal(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got uint64
+		if err := Unmarshal(b, &got); err != nil {
+			t.Fatalf("Unmarshal(%x): %v", b, err)
+		}
+		if got != want {
+			t.Fatalf("round trip = %d, want %d", got, want)
+		}
+	}
+}

--- a/internal/postcard/postcard_test.go
+++ b/internal/postcard/postcard_test.go
@@ -359,3 +359,85 @@ func TestCanonicalVarintsStillDecode(t *testing.T) {
 		}
 	}
 }
+
+// legacyUint8 and legacyInt8 are the pre-v0 8-bit encodings: uint8 as a varint
+// and int8 as a zigzag varint. They exist so the compatibility boundary below
+// is stated in code rather than in a comment.
+func legacyUint8(v uint8) []byte { return appendVarint(nil, uint64(v)) }
+
+func legacyInt8(v int8) []byte { return appendVarint(nil, zigzag(int64(v))) }
+
+// TestByteSizedCompatibilityBoundary pins exactly which values the switch to
+// raw-byte u8/i8 changed. Records that carry only small u8 tags — every 8-bit
+// field shipped so far is a tag in 1..7 — encode identically before and after,
+// so they stay readable; a u8 of 128 or more does not, and neither does any
+// nonzero i8. A later 8-bit field that can exceed 127 has to break this test
+// before it can silently break stored records.
+func TestByteSizedCompatibilityBoundary(t *testing.T) {
+	for v := 0; v < 128; v++ {
+		got, err := Marshal(uint8(v))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := legacyUint8(uint8(v)); !reflect.DeepEqual(got, want) {
+			t.Fatalf("uint8(%d) = %x, want %x: small tags must encode as before", v, got, want)
+		}
+		if len(got) != 1 {
+			t.Fatalf("uint8(%d) = %x, want one byte", v, got)
+		}
+	}
+	for v := 128; v < 256; v++ {
+		got, err := Marshal(uint8(v))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reflect.DeepEqual(got, legacyUint8(uint8(v))) {
+			t.Fatalf("uint8(%d) = %x, want a change from the two-byte varint", v, got)
+		}
+	}
+	// i8 is the dangerous half: zigzag moves every nonzero value.
+	if got, err := Marshal(int8(0)); err != nil || !reflect.DeepEqual(got, legacyInt8(0)) {
+		t.Fatalf("int8(0) = %x, %v, want %x", got, err, legacyInt8(0))
+	}
+	for v := -128; v < 128; v++ {
+		if v == 0 {
+			continue
+		}
+		got, err := Marshal(int8(v))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reflect.DeepEqual(got, legacyInt8(int8(v))) {
+			t.Fatalf("int8(%d) = %x, want a change from the zigzag varint", v, got)
+		}
+	}
+}
+
+// TestSmallTagRecordsUnchanged pins the shape the landed experiment records use:
+// a small u8 tag followed by the rest of the struct. Every such record encodes
+// the same before and after the 8-bit change.
+func TestSmallTagRecordsUnchanged(t *testing.T) {
+	type tagged struct {
+		Kind    uint8
+		Version uint8
+		Payload []byte
+	}
+	for kind := uint8(1); kind <= 7; kind++ {
+		v := tagged{Kind: kind, Version: 1, Payload: []byte{0xde, 0xad}}
+		got, err := Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := append(append(legacyUint8(kind), legacyUint8(1)...), 0x02, 0xde, 0xad)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("kind %d: Marshal = %x, want %x", kind, got, want)
+		}
+		var back tagged
+		if err := Unmarshal(got, &back); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(back, v) {
+			t.Fatalf("kind %d: round trip = %#v, want %#v", kind, back, v)
+		}
+	}
+}


### PR DESCRIPTION
Encodes u8/i8 as one raw byte, rejects non-canonical varints, and pins the 8-bit compatibility boundary with tests.