### PR TITLE
qng: estimate the payload size on both ACK paths

### DIFF
--- a/internal/qng/anchor.go
+++ b/internal/qng/anchor.go
@@ -1,9 +1,13 @@
 //go:build qng_regenerate
 
 // Package quic is internal/qng, a vendored fork of quic-go. This file exists
-// only to keep github.com/quic-go/quic-go in the module graph (and thus in the
-// module cache) so regenerate.sh can re-fork it; it is never built. See
-// README.md.
+// only to keep github.com/quic-go/quic-go in the module graph; it is never
+// built. See README.md.
+//
+// The graph edge serves two purposes. It records which quic-go release this
+// fork derives from, so that anyone auditing go-iroh's dependencies sees the
+// provenance in go.mod without reading this directory. It also pins the
+// version that the regeneration procedure re-forks from the module cache.
 package quic
 
 import _ "github.com/quic-go/quic-go"

--- a/internal/qng/connection.go
+++ b/internal/qng/connection.go
@@ -2899,8 +2899,9 @@ func (c *Conn) handleAckFrame(frame *wire.AckFrame, encLevel protocol.Encryption
 	}
 	// If one of the acknowledged packets was a Path MTU probe packet, this might have increased the Path MTU estimate.
 	if c.mtuDiscoverer != nil {
-		if mtu := c.mtuDiscoverer.CurrentSize(); mtu > protocol.ByteCount(c.currentMTUEstimate.Load()) {
-			c.currentMTUEstimate.Store(uint32(mtu))
+		mtu := c.mtuDiscoverer.CurrentSize()
+		if maxPayloadSize := estimateMaxPayloadSize(mtu); maxPayloadSize > protocol.ByteCount(c.currentMTUEstimate.Load()) {
+			c.currentMTUEstimate.Store(uint32(maxPayloadSize))
 			c.sentPacketHandler.SetMaxDatagramSize(mtu)
 		}
 	}
@@ -2931,8 +2932,9 @@ func (c *Conn) handleAckFrameForPath(frame *wire.AckFrame, pid protocol.PathID, 
 		}
 	}
 	if c.mtuDiscoverer != nil {
-		if mtu := c.mtuDiscoverer.CurrentSize(); mtu > protocol.ByteCount(c.currentMTUEstimate.Load()) {
-			c.currentMTUEstimate.Store(uint32(mtu))
+		mtu := c.mtuDiscoverer.CurrentSize()
+		if maxPayloadSize := estimateMaxPayloadSize(mtu); maxPayloadSize > protocol.ByteCount(c.currentMTUEstimate.Load()) {
+			c.currentMTUEstimate.Store(uint32(maxPayloadSize))
 			c.sentPacketHandler.SetMaxDatagramSize(mtu)
 		}
 	}


### PR DESCRIPTION
Fixes MaxDatagramSize over-reporting by the header size after a PMTU or PATH_ACK advance, and documents why the quic-go module edge exists.