### PR TITLE
iroh/mdns: answer multicast queries

### DIFF
--- a/iroh/mdns/dnsmsg.go
+++ b/iroh/mdns/dnsmsg.go
@@ -18,6 +18,7 @@ const (
 	dnsTypeTXT  uint16 = 16
 	dnsTypeAAAA uint16 = 28
 	dnsTypeSRV  uint16 = 33
+	dnsTypeANY  uint16 = 255
 	dnsClassIN  uint16 = 1
 )
 
@@ -247,6 +248,43 @@ func parseAnnouncement(packet []byte, service string) (dns.EndpointInfo, bool) {
 		return infoFromAnnouncement(data), true
 	}
 	return dns.EndpointInfo{}, false
+}
+
+// dnsQuestion is one question from a multicast query.
+type dnsQuestion struct {
+	name string
+	typ  uint16
+}
+
+// parseQuestions returns the questions in packet. It reports false for a
+// response, a packet with no questions, and a malformed one: only a query is
+// worth answering.
+func parseQuestions(packet []byte) ([]dnsQuestion, bool) {
+	if len(packet) < 12 {
+		return nil, false
+	}
+	if binary.BigEndian.Uint16(packet[2:4])&0x8000 != 0 {
+		return nil, false // a response
+	}
+	qd := int(binary.BigEndian.Uint16(packet[4:6]))
+	if qd == 0 {
+		return nil, false
+	}
+	off := 12
+	questions := make([]dnsQuestion, 0, qd)
+	for i := 0; i < qd; i++ {
+		name, next, err := readName(packet, off)
+		if err != nil {
+			return nil, false
+		}
+		off = next
+		if off+4 > len(packet) {
+			return nil, false
+		}
+		questions = append(questions, dnsQuestion{name: name, typ: binary.BigEndian.Uint16(packet[off : off+2])})
+		off += 4
+	}
+	return questions, true
 }
 
 type dnsMessage struct {

--- a/iroh/mdns/doc.go
+++ b/iroh/mdns/doc.go
@@ -7,5 +7,11 @@
 // iroh.AddressPublisher and iroh.AddressResolver, so it can be registered with
 // iroh.AddressLookupServices.
 //
+// The transport is IPv4 only: a Discovery listens on udp4 and multicasts to
+// 224.0.0.251, not to ff02::fb, so two peers that share only an IPv6 link do
+// not find each other. The addresses it carries are not restricted that way.
+// AAAA records ride the IPv4 packets, because an IPv6 address learned over an
+// IPv4 link is still dialable.
+//
 // The Go API is not stable before v1 and may change in any v0 release.
 package mdns

--- a/iroh/mdns/mdns.go
+++ b/iroh/mdns/mdns.go
@@ -13,11 +13,9 @@ import (
 	"math/rand/v2"
 	"net"
 	"net/netip"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/tmc/go-iroh/dns"
@@ -25,7 +23,6 @@ import (
 	"github.com/tmc/go-iroh/key"
 	"github.com/tmc/go-iroh/netaddr"
 	"golang.org/x/net/ipv4"
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -210,24 +207,6 @@ func listenIPv4MDNS(ctx context.Context) (*net.UDPConn, error) {
 		}
 	}
 	return conn, nil
-}
-
-func reusePortControl(_, _ string, c syscall.RawConn) error {
-	var firstErr error
-	err := c.Control(func(fd uintptr) {
-		if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		if runtime.GOOS != "windows" {
-			if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
-	})
-	if err != nil {
-		return err
-	}
-	return firstErr
 }
 
 // Publish advertises data on the local network. It is fire-and-forget and

--- a/iroh/mdns/mdns.go
+++ b/iroh/mdns/mdns.go
@@ -40,7 +40,6 @@ const (
 
 var (
 	ipv4Multicast = netip.MustParseAddrPort("224.0.0.251:5353")
-	ipv6Multicast = netip.MustParseAddrPort("[ff02::fb]:5353")
 
 	errNoAddresses = errors.New("mdns: endpoint data has no IP addresses")
 )
@@ -536,5 +535,4 @@ func infoFromAnnouncement(a announcementData) dns.EndpointInfo {
 var (
 	_ iroh.AddressPublisher = (*Discovery)(nil)
 	_ iroh.AddressResolver  = (*Discovery)(nil)
-	_                       = ipv6Multicast
 )

--- a/iroh/mdns/mdns.go
+++ b/iroh/mdns/mdns.go
@@ -10,6 +10,7 @@ import (
 	"iter"
 	"log/slog"
 	"maps"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"runtime"
@@ -57,10 +58,15 @@ type Discovery struct {
 	passive     bool
 	timeout     time.Duration
 	logger      *slog.Logger
+	// responseDelay is how long to wait before answering a query. RFC 6762
+	// section 6 asks for a random 20-120ms so that simultaneous responders
+	// do not collide. Tests replace it.
+	responseDelay func() time.Duration
 
-	mu    sync.RWMutex
-	peers map[key.EndpointID]peerInfo
-	conn  *net.UDPConn
+	mu        sync.RWMutex
+	peers     map[key.EndpointID]peerInfo
+	conn      *net.UDPConn
+	announced []byte // last announcement built by Publish, replayed to queries
 }
 
 type peerInfo struct {
@@ -117,7 +123,10 @@ func New(id key.EndpointID, opts ...Option) *Discovery {
 		serviceName: DefaultServiceName,
 		timeout:     defaultLookupTimeout,
 		logger:      slog.Default(),
-		peers:       make(map[key.EndpointID]peerInfo),
+		responseDelay: func() time.Duration {
+			return 20*time.Millisecond + time.Duration(rand.Int64N(int64(100*time.Millisecond)))
+		},
+		peers: make(map[key.EndpointID]peerInfo),
 	}
 	for _, opt := range opts {
 		opt(d)
@@ -125,9 +134,12 @@ func New(id key.EndpointID, opts ...Option) *Discovery {
 	return d
 }
 
-// Start listens for mDNS packets until ctx is cancelled. It is safe to call
-// Publish before Start, but Resolve only observes remote responses while Start
-// is running.
+// Start listens for mDNS packets until ctx is cancelled. It caches the
+// announcements it sees and answers queries for the service, or for this
+// endpoint's instance, with the endpoint's most recent announcement, after the
+// random delay RFC 6762 section 6 requires. It is safe to call Publish before
+// Start, but a Discovery answers queries and observes remote responses only
+// while Start is running.
 func (d *Discovery) Start(ctx context.Context) error {
 	if d == nil {
 		return errors.New("mdns: nil Discovery")
@@ -248,7 +260,9 @@ func (d *Discovery) log() *slog.Logger {
 
 // Resolve returns the cached item for id, if present, and otherwise sends a
 // multicast query and waits for a matching response until ctx or the lookup
-// timeout fires.
+// timeout fires. The response comes from the peer's own [Discovery.Start] loop,
+// so the peer must be running one; a peer that only published once and stopped
+// listening cannot answer.
 func (d *Discovery) Resolve(ctx context.Context, id key.EndpointID) iter.Seq2[iroh.Item, error] {
 	if d == nil {
 		return nil
@@ -294,6 +308,7 @@ func (d *Discovery) item(id key.EndpointID) (iroh.Item, bool) {
 func (d *Discovery) handlePacket(packet []byte) {
 	info, ok := parseAnnouncement(packet, d.serviceName)
 	if !ok {
+		d.answerQuery(packet)
 		return
 	}
 	d.mu.Lock()
@@ -305,6 +320,56 @@ func (d *Discovery) handlePacket(packet []byte) {
 		lastUpdated: uint64(time.Now().UnixMicro()),
 	}
 	d.mu.Unlock()
+}
+
+// answerFor returns the announcement to multicast in reply to packet, and
+// whether packet is a query this Discovery should answer: one asking for the
+// service, or for this endpoint's own instance. A Discovery that publishes
+// nothing answers nothing.
+func (d *Discovery) answerFor(packet []byte) ([]byte, bool) {
+	if d.passive {
+		return nil, false
+	}
+	d.mu.RLock()
+	announced := d.announced
+	d.mu.RUnlock()
+	if len(announced) == 0 {
+		return nil, false
+	}
+	questions, ok := parseQuestions(packet)
+	if !ok {
+		return nil, false
+	}
+	service := serviceName(d.serviceName)
+	instance := instanceName(d.serviceName, d.id)
+	for _, q := range questions {
+		if q.typ != dnsTypePTR && q.typ != dnsTypeANY {
+			continue
+		}
+		if strings.EqualFold(q.name, service) || strings.EqualFold(q.name, instance) {
+			return announced, true
+		}
+	}
+	return nil, false
+}
+
+// answerQuery multicasts this endpoint's announcement if packet is a query it
+// should answer, and reports whether it started a response.
+func (d *Discovery) answerQuery(packet []byte) bool {
+	answer, ok := d.answerFor(packet)
+	if !ok {
+		return false
+	}
+	go d.respond(answer)
+	return true
+}
+
+// respond multicasts answer after the response delay.
+func (d *Discovery) respond(answer []byte) {
+	timer := time.NewTimer(d.responseDelay())
+	defer timer.Stop()
+	<-timer.C
+	d.writeMulticast(answer)
 }
 
 func (d *Discovery) query(id key.EndpointID) {
@@ -335,12 +400,21 @@ func (d *Discovery) writeMulticast(packet []byte) {
 	_, _ = conn.WriteToUDPAddrPort(packet, ipv4Multicast)
 }
 
+// announcement builds the announcement packet for data and records it as the
+// answer to later queries.
 func (d *Discovery) announcement(data dns.EndpointData) ([]byte, error) {
 	info, err := d.announcementInfo(data)
 	if err != nil {
 		return nil, err
 	}
-	return buildAnnouncement(d.serviceName, info)
+	packet, err := buildAnnouncement(d.serviceName, info)
+	if err != nil {
+		return nil, err
+	}
+	d.mu.Lock()
+	d.announced = packet
+	d.mu.Unlock()
+	return packet, nil
 }
 
 type announcementData struct {

--- a/iroh/mdns/mdns.go
+++ b/iroh/mdns/mdns.go
@@ -8,9 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"log/slog"
+	"maps"
 	"net"
 	"net/netip"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -43,11 +46,17 @@ var (
 
 // Discovery publishes and resolves iroh endpoint addressing information over
 // multicast DNS. The zero value is not usable; create one with [New].
+//
+// One DNS-SD instance carries one SRV record and so one port. An endpoint whose
+// direct addresses do not all share a port is announced on the port most of
+// them use, lowest port first on a tie, and the rest are dropped; see
+// [Discovery.Publish] for how that is reported.
 type Discovery struct {
 	id          key.EndpointID
 	serviceName string
 	passive     bool
 	timeout     time.Duration
+	logger      *slog.Logger
 
 	mu    sync.RWMutex
 	peers map[key.EndpointID]peerInfo
@@ -89,6 +98,17 @@ func WithLookupTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithLogger sets the logger for events a fire-and-forget [Discovery.Publish]
+// cannot report to its caller, such as endpoint data it cannot announce. The
+// default is [slog.Default].
+func WithLogger(logger *slog.Logger) Option {
+	return func(d *Discovery) {
+		if logger != nil {
+			d.logger = logger
+		}
+	}
+}
+
 // New returns a Discovery for id using the default iroh local-network service
 // name.
 func New(id key.EndpointID, opts ...Option) *Discovery {
@@ -96,6 +116,7 @@ func New(id key.EndpointID, opts ...Option) *Discovery {
 		id:          id,
 		serviceName: DefaultServiceName,
 		timeout:     defaultLookupTimeout,
+		logger:      slog.Default(),
 		peers:       make(map[key.EndpointID]peerInfo),
 	}
 	for _, opt := range opts {
@@ -199,16 +220,30 @@ func reusePortControl(_, _ string, c syscall.RawConn) error {
 }
 
 // Publish advertises data on the local network. It is fire-and-forget and
-// returns immediately, matching iroh.AddressPublisher.
+// returns immediately, matching iroh.AddressPublisher, so what it cannot
+// announce it reports to the logger given to [WithLogger] instead of to the
+// caller: endpoint data with no direct IP address (a relay-only endpoint
+// announces nothing) and addresses dropped by the single-port rule described on
+// [Discovery].
 func (d *Discovery) Publish(data dns.EndpointData) {
 	if d == nil || d.passive {
 		return
 	}
 	packet, err := d.announcement(data)
 	if err != nil {
+		d.log().Warn("mdns: not announcing endpoint data", "endpoint", d.id, "err", err)
 		return
 	}
 	go d.writeMulticast(packet)
+}
+
+// log returns the configured logger, or the default one for a Discovery built
+// before WithLogger existed or by a zero value.
+func (d *Discovery) log() *slog.Logger {
+	if d.logger == nil {
+		return slog.Default()
+	}
+	return d.logger
 }
 
 // Resolve returns the cached item for id, if present, and otherwise sends a
@@ -322,16 +357,24 @@ func (d *Discovery) announcementInfo(data dns.EndpointData) (announcementData, e
 		return announcementData{}, errNoAddresses
 	}
 	out := announcementData{id: d.id}
-	port := ipAddrs[0].Port()
-	out.port = port
+	out.port = announcementPort(ipAddrs)
+	var dropped []netip.AddrPort
 	for _, addr := range ipAddrs {
-		if addr.Port() != port || !addr.Addr().IsValid() {
+		if !addr.Addr().IsValid() {
+			continue
+		}
+		if addr.Port() != out.port {
+			dropped = append(dropped, addr)
 			continue
 		}
 		out.ips = append(out.ips, netip.AddrPortFrom(addr.Addr().Unmap(), addr.Port()))
 	}
 	if len(out.ips) == 0 {
 		return announcementData{}, errNoAddresses
+	}
+	if len(dropped) > 0 {
+		d.log().Warn("mdns: announcing one port only, dropping addresses on others",
+			"endpoint", d.id, "port", out.port, "dropped", dropped)
 	}
 	if relays := data.RelayURLs(); len(relays) != 0 {
 		if s := relays[0].String(); len(s) <= 249 {
@@ -342,6 +385,27 @@ func (d *Discovery) announcementInfo(data dns.EndpointData) (announcementData, e
 		out.userData = u.String()
 	}
 	return out, nil
+}
+
+// announcementPort returns the port to announce for addrs. One DNS-SD instance
+// has one SRV record and so one port; the port shared by the most addresses
+// keeps the most of them, and the lowest such port breaks ties so that repeated
+// announcements of the same address set are identical.
+func announcementPort(addrs []netip.AddrPort) uint16 {
+	counts := make(map[uint16]int, len(addrs))
+	for _, addr := range addrs {
+		if addr.Addr().IsValid() {
+			counts[addr.Port()]++
+		}
+	}
+	var best uint16
+	bestCount := 0
+	for _, port := range slices.Sorted(maps.Keys(counts)) {
+		if counts[port] > bestCount {
+			best, bestCount = port, counts[port]
+		}
+	}
+	return best
 }
 
 func cloneEndpointData(data dns.EndpointData) dns.EndpointData {

--- a/iroh/mdns/mdns_js.go
+++ b/iroh/mdns/mdns_js.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"iter"
+	"log/slog"
 	"time"
 
 	"github.com/tmc/go-iroh/dns"
@@ -29,6 +30,7 @@ type Discovery struct {
 	serviceName string
 	passive     bool
 	timeout     time.Duration
+	logger      *slog.Logger
 }
 
 // Option configures a Discovery.
@@ -57,6 +59,17 @@ func WithLookupTimeout(timeout time.Duration) Option {
 	return func(d *Discovery) {
 		if timeout > 0 {
 			d.timeout = timeout
+		}
+	}
+}
+
+// WithLogger sets the logger for events a fire-and-forget [Discovery.Publish]
+// cannot report to its caller. Nothing is published in js/wasm, so nothing is
+// logged; the option exists so code builds for both targets.
+func WithLogger(logger *slog.Logger) Option {
+	return func(d *Discovery) {
+		if logger != nil {
+			d.logger = logger
 		}
 	}
 }

--- a/iroh/mdns/mdns_test.go
+++ b/iroh/mdns/mdns_test.go
@@ -265,3 +265,129 @@ func TestPublishLogsWhatItCannotAnnounce(t *testing.T) {
 		})
 	}
 }
+
+// TestAnswerForQuery checks the responder's decision: a Discovery answers a PTR
+// query for its service or its own instance with its last announcement, and
+// answers nothing else.
+func TestAnswerForQuery(t *testing.T) {
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := sk.Public().EndpointID()
+	other, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := dns.NewEndpointData().WithIPAddrs(netip.MustParseAddrPort("192.0.2.1:7777"))
+
+	serviceQuery, err := buildQuery(serviceName(DefaultServiceName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownQuery, err := buildQuery(instanceName(DefaultServiceName, id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherQuery, err := buildQuery(instanceName(DefaultServiceName, other.Public().EndpointID()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range []struct {
+		name      string
+		published bool
+		passive   bool
+		packet    []byte
+		want      bool
+	}{
+		{name: "service query", published: true, packet: serviceQuery, want: true},
+		{name: "own instance query", published: true, packet: ownQuery, want: true},
+		{name: "another instance query", published: true, packet: otherQuery},
+		{name: "nothing published yet", packet: serviceQuery},
+		{name: "passive", published: true, passive: true, packet: serviceQuery},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New(id, WithPassive(tt.passive))
+			if tt.published {
+				if _, err := d.announcement(data); err != nil {
+					t.Fatalf("announcement: %v", err)
+				}
+			}
+			answer, ok := d.answerFor(tt.packet)
+			if ok != tt.want {
+				t.Fatalf("answerFor = %v, want %v", ok, tt.want)
+			}
+			if !ok {
+				return
+			}
+			info, ok := parseAnnouncement(answer, DefaultServiceName)
+			if !ok {
+				t.Fatal("answer is not a parseable announcement")
+			}
+			if !info.ID.Equal(id) {
+				t.Fatalf("answer announces %s, want %s", info.ID, id)
+			}
+		})
+	}
+
+	// An announcement must not be answered, or two listeners would answer each
+	// other forever.
+	d := New(id)
+	if _, err := d.announcement(data); err != nil {
+		t.Fatal(err)
+	}
+	announcement, err := d.announcement(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := d.answerFor(announcement); ok {
+		t.Fatal("answered an announcement")
+	}
+}
+
+// TestHandlePacketAnswersQueries checks that the read loop routes a query to
+// the responder and an announcement to the cache. The response delay is set
+// past the end of the test so nothing is multicast from here.
+func TestHandlePacketAnswersQueries(t *testing.T) {
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := sk.Public().EndpointID()
+	d := New(id)
+	d.responseDelay = func() time.Duration { return time.Hour }
+	if _, err := d.announcement(dns.NewEndpointData().WithIPAddrs(netip.MustParseAddrPort("192.0.2.1:7777"))); err != nil {
+		t.Fatal(err)
+	}
+
+	query, err := buildQuery(serviceName(DefaultServiceName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.answerQuery(query) {
+		t.Fatal("a service query was not answered")
+	}
+	d.handlePacket(query)
+	if _, ok := d.item(id); ok {
+		t.Fatal("a query was cached as an announcement")
+	}
+
+	peer, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerID := peer.Public().EndpointID()
+	peerDiscovery := New(peerID)
+	announcement, err := peerDiscovery.announcement(dns.NewEndpointData().WithIPAddrs(netip.MustParseAddrPort("192.0.2.9:7777")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.handlePacket(announcement)
+	if _, ok := d.item(peerID); !ok {
+		t.Fatal("an announcement was not cached")
+	}
+	if d.answerQuery(announcement) {
+		t.Fatal("an announcement was answered")
+	}
+}

--- a/iroh/mdns/mdns_test.go
+++ b/iroh/mdns/mdns_test.go
@@ -3,8 +3,11 @@
 package mdns
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/netip"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,4 +181,87 @@ func sameAddrPorts(a, b []netip.AddrPort) bool {
 		seen[addr]--
 	}
 	return true
+}
+
+func TestAnnouncementPort(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		addrs []string
+		want  uint16
+	}{
+		{name: "single", addrs: []string{"192.0.2.1:7777"}, want: 7777},
+		{
+			name:  "majority wins over first",
+			addrs: []string{"192.0.2.1:1111", "192.0.2.2:7777", "[2001:db8::1]:7777"},
+			want:  7777,
+		},
+		{
+			name:  "lowest port breaks a tie",
+			addrs: []string{"192.0.2.1:9999", "192.0.2.2:7777"},
+			want:  7777,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var addrs []netip.AddrPort
+			for _, a := range tt.addrs {
+				addrs = append(addrs, netip.MustParseAddrPort(a))
+			}
+			if got := announcementPort(addrs); got != tt.want {
+				t.Fatalf("announcementPort(%v) = %d, want %d", tt.addrs, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPublishLogsWhatItCannotAnnounce checks that the two things Publish cannot
+// tell its fire-and-forget caller reach the logger instead.
+func TestPublishLogsWhatItCannotAnnounce(t *testing.T) {
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relay, err := netaddr.ParseRelayURL("https://relay.example/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name string
+		data dns.EndpointData
+		// announce reaches the same code Publish does without the multicast
+		// write, for the case where an announcement is actually built.
+		announce bool
+		want     string
+	}{
+		{
+			name: "relay only",
+			data: dns.NewEndpointData().WithRelayURL(relay),
+			want: "not announcing endpoint data",
+		},
+		{
+			name: "addresses on another port",
+			data: dns.NewEndpointData().WithIPAddrs(
+				netip.MustParseAddrPort("192.0.2.1:7777"),
+				netip.MustParseAddrPort("192.0.2.2:7777"),
+				netip.MustParseAddrPort("192.0.2.3:9999"),
+			),
+			announce: true,
+			want:     "dropping addresses on others",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, nil))
+			d := New(sk.Public().EndpointID(), WithLogger(logger))
+			if tt.announce {
+				if _, err := d.announcement(tt.data); err != nil {
+					t.Fatalf("announcement: %v", err)
+				}
+			} else {
+				d.Publish(tt.data)
+			}
+			if !strings.Contains(logs.String(), tt.want) {
+				t.Fatalf("logged %q, want it to mention %q", logs.String(), tt.want)
+			}
+		})
+	}
 }

--- a/iroh/mdns/reuse_unix.go
+++ b/iroh/mdns/reuse_unix.go
@@ -1,0 +1,25 @@
+//go:build !js && !windows
+
+package mdns
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func reusePortControl(_, _ string, c syscall.RawConn) error {
+	var firstErr error
+	err := c.Control(func(fd uintptr) {
+		if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	})
+	if err != nil {
+		return err
+	}
+	return firstErr
+}

--- a/iroh/mdns/reuse_windows.go
+++ b/iroh/mdns/reuse_windows.go
@@ -1,0 +1,14 @@
+package mdns
+
+import "syscall"
+
+func reusePortControl(_, _ string, c syscall.RawConn) error {
+	var sockErr error
+	err := c.Control(func(fd uintptr) {
+		sockErr = syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+	})
+	if err != nil {
+		return err
+	}
+	return sockErr
+}


### PR DESCRIPTION
Answers multicast queries, documents the IPv4-only transport and what Publish cannot announce, and splits socket reuse into platform files.