### PR TITLE
gossip: keep the topic event stream open across a lagging subscriber

### DIFF
--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -394,3 +394,67 @@ func nextEvent(ctx context.Context, t *testing.T, topic *gossip.Topic) gossip.Ev
 	}
 	return gossip.Event{}
 }
+
+// TestGossipTopicEventsBufferedBeforeFirstRead checks that the event stream
+// starts at Subscribe and not at the first call to Events: a caller that joins
+// the topic and only then reads still sees the NeighborUp it missed.
+func TestGossipTopicEventsBufferedBeforeFirstRead(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var topic gossip.TopicID
+	copy(topic[:], "buffered")
+
+	server, err := iroh.Bind(ctx, iroh.WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)))
+	if err != nil {
+		t.Fatalf("bind server: %v", err)
+	}
+	serverGossip := gossip.NewGossip(server)
+	serverRouter, err := iroh.NewRouter(server, map[string]iroh.ProtocolHandler{
+		gossip.ALPN: serverGossip.Handler(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("new server router: %v", err)
+	}
+	defer serverRouter.Shutdown(ctx)
+
+	client, err := iroh.Bind(ctx, iroh.WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)))
+	if err != nil {
+		t.Fatalf("bind client: %v", err)
+	}
+	clientGossip := gossip.NewGossip(client)
+	clientRouter, err := iroh.NewRouter(client, map[string]iroh.ProtocolHandler{
+		gossip.ALPN: clientGossip.Handler(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("new client router: %v", err)
+	}
+	defer clientRouter.Shutdown(ctx)
+
+	serverTopic, err := serverGossip.Subscribe(ctx, topic, nil)
+	if err != nil {
+		t.Fatalf("server subscribe: %v", err)
+	}
+	defer serverTopic.Close()
+
+	serverAddr := netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr())
+	clientTopic, err := clientGossip.Subscribe(ctx, topic, []netaddr.EndpointAddr{serverAddr})
+	if err != nil {
+		t.Fatalf("client subscribe: %v", err)
+	}
+	defer clientTopic.Close()
+
+	// Wait for the join with the state-based accessor, which does not consume
+	// events, so nothing has read the stream by the time Events is called.
+	for len(clientTopic.Neighbors()) == 0 {
+		select {
+		case <-ctx.Done():
+			t.Fatal("client never joined")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	if ev := nextEvent(ctx, t, clientTopic); ev.Kind != gossip.NeighborUp {
+		t.Fatalf("first event after join = %+v, want NeighborUp", ev)
+	}
+}

--- a/gossip/gossip_test.go
+++ b/gossip/gossip_test.go
@@ -458,3 +458,87 @@ func TestGossipTopicEventsBufferedBeforeFirstRead(t *testing.T) {
 		t.Fatalf("first event after join = %+v, want NeighborUp", ev)
 	}
 }
+
+// TestGossipTopicJoinedAlongsideEvents checks that Joined and Events can run at
+// the same time. Joined used to read the subscription queue, so the two raced
+// for the same NeighborUp and the test pins both outcomes: whichever won, the
+// loser was starved. It requires that Joined returns and that the iterator
+// still sees NeighborUp, so it fails either way against the old code.
+func TestGossipTopicJoinedAlongsideEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var topic gossip.TopicID
+	copy(topic[:], "alongside")
+
+	server, err := iroh.Bind(ctx, iroh.WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)))
+	if err != nil {
+		t.Fatalf("bind server: %v", err)
+	}
+	serverGossip := gossip.NewGossip(server)
+	serverRouter, err := iroh.NewRouter(server, map[string]iroh.ProtocolHandler{
+		gossip.ALPN: serverGossip.Handler(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("new server router: %v", err)
+	}
+	defer serverRouter.Shutdown(ctx)
+
+	client, err := iroh.Bind(ctx, iroh.WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)))
+	if err != nil {
+		t.Fatalf("bind client: %v", err)
+	}
+	clientGossip := gossip.NewGossip(client)
+	clientRouter, err := iroh.NewRouter(client, map[string]iroh.ProtocolHandler{
+		gossip.ALPN: clientGossip.Handler(),
+	}, nil)
+	if err != nil {
+		t.Fatalf("new client router: %v", err)
+	}
+	defer clientRouter.Shutdown(ctx)
+
+	serverTopic, err := serverGossip.Subscribe(ctx, topic, nil)
+	if err != nil {
+		t.Fatalf("server subscribe: %v", err)
+	}
+	defer serverTopic.Close()
+
+	serverAddr := netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr())
+	clientTopic, err := clientGossip.Subscribe(ctx, topic, []netaddr.EndpointAddr{serverAddr})
+	if err != nil {
+		t.Fatalf("client subscribe: %v", err)
+	}
+	defer clientTopic.Close()
+
+	// An Events iterator running for the whole test: it, not Joined, must be
+	// the one that sees NeighborUp.
+	events := make(chan gossip.Event, 8)
+	go func() {
+		for ev, err := range clientTopic.Events() {
+			if err != nil {
+				return
+			}
+			select {
+			case events <- ev:
+			default:
+			}
+		}
+	}()
+
+	joinCtx, joinCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer joinCancel()
+	if err := clientTopic.Joined(joinCtx); err != nil {
+		t.Fatalf("joined alongside events: %v", err)
+	}
+
+	for {
+		select {
+		case ev := <-events:
+			if ev.Kind == gossip.NeighborUp {
+				return
+			}
+		case <-ctx.Done():
+			t.Fatal("events iterator never saw NeighborUp")
+		}
+	}
+}

--- a/gossip/topic.go
+++ b/gossip/topic.go
@@ -18,7 +18,11 @@ const defaultTopicEventCap = 2048
 
 // JoinOptions configures a topic subscription.
 type JoinOptions struct {
-	Bootstrap            []netaddr.EndpointAddr
+	// Bootstrap are the peers dialed to join the topic's overlay.
+	Bootstrap []netaddr.EndpointAddr
+
+	// SubscriptionCapacity is the number of events the subscription buffers
+	// for a receiver that is not reading yet. Zero means 2048.
 	SubscriptionCapacity int
 }
 
@@ -612,6 +616,13 @@ func (t *Topic) Neighbors() []key.EndpointID {
 }
 
 // Events returns the topic event stream.
+//
+// The stream starts at Subscribe, not at the call to Events: events that
+// arrive before the first call are buffered, so a caller that joins peers and
+// only then reads still sees the NeighborUp events for that join. The buffer
+// holds [JoinOptions.SubscriptionCapacity] events; a receiver that falls
+// further behind loses events and sees a single [Lagged] event marking the
+// gap, but keeps the stream. Only [Topic.Close] ends it.
 func (t *Topic) Events() iter.Seq2[Event, error] {
 	return func(yield func(Event, error) bool) {
 		for ev := range t.events {

--- a/gossip/topic.go
+++ b/gossip/topic.go
@@ -34,7 +34,14 @@ const (
 	Received
 	// PeerData reports metadata propagated by the topic membership overlay.
 	PeerData
-	// Lagged reports that a slow receiver missed one or more events.
+	// Lagged reports that a slow receiver missed events; [Event.Dropped]
+	// says how many. The stream continues after it; the receiver has lost
+	// the dropped events, not the subscription.
+	//
+	// A full subscription queue drops the newest event, not the oldest, so
+	// the marker is delivered in the position the loss happened. Rust
+	// iroh-gossip rides a tokio broadcast channel and drops the oldest
+	// instead; the divergence is deliberate, not a porting mistake.
 	Lagged
 )
 
@@ -59,6 +66,9 @@ type Event struct {
 	// Round is the PlumTree delivery round for DeliverySwarm messages.
 	// It is zero for direct-neighbor delivery.
 	Round uint16
+	// Dropped is the number of events lost before a [Lagged] event. It is
+	// zero for every other kind.
+	Dropped uint64
 }
 
 // GossipOption configures a Gossip instance.
@@ -500,8 +510,9 @@ type Topic struct {
 	id     TopicID
 	events chan Event
 
-	mu     sync.Mutex
-	closed bool
+	mu      sync.Mutex
+	closed  bool
+	dropped uint64 // events dropped since the last Lagged; a marker is owed while non-zero
 }
 
 // ID returns the topic ID.
@@ -673,29 +684,31 @@ func (r *Receiver) Neighbors() []key.EndpointID {
 	return out
 }
 
+// sendEvent queues ev for the topic's subscriber. A subscriber that is not
+// keeping up loses events, not the stream: sendEvent drops ev and counts it,
+// and the next event the subscriber can accept is preceded by one Lagged event
+// reporting how many were lost. Only [Topic.closeEvents] closes the stream.
 func (t *Topic) sendEvent(ev Event) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.closed {
 		return
 	}
+	if t.dropped > 0 {
+		// Report the gap before any event that follows it, so the subscriber
+		// learns of the loss in the order it happened.
+		select {
+		case t.events <- Event{Kind: Lagged, Dropped: t.dropped}:
+			t.dropped = 0
+		default:
+			t.dropped++
+			return
+		}
+	}
 	select {
 	case t.events <- ev:
 	default:
-		select {
-		case t.events <- Event{Kind: Lagged}:
-		default:
-			select {
-			case <-t.events:
-			default:
-			}
-			select {
-			case t.events <- Event{Kind: Lagged}:
-			default:
-			}
-		}
-		t.closed = true
-		close(t.events)
+		t.dropped++
 	}
 }
 

--- a/gossip/topic.go
+++ b/gossip/topic.go
@@ -103,6 +103,9 @@ type Gossip struct {
 	peerSenders map[PeerID]*Sender
 	metrics     gossipMetrics
 	closed      bool
+	// joinWait is closed and replaced whenever a topic's neighbor set
+	// changes or a topic closes, waking every Joined caller.
+	joinWait chan struct{}
 }
 
 // NewGossip returns a Gossip instance for ep.
@@ -173,6 +176,7 @@ func (g *Gossip) Shutdown(ctx context.Context) {
 		}
 	}
 	g.topics = make(map[TopicID]map[*Topic]struct{})
+	g.wakeJoinWaiters()
 	senders := make([]*Sender, 0, len(g.peerSenders))
 	for peer, sender := range g.peerSenders {
 		delete(g.peerSenders, peer)
@@ -335,6 +339,7 @@ func (g *Gossip) closeTopic(t *Topic) error {
 		t.closeEvents()
 	}
 	delete(g.topics[t.id], t)
+	g.wakeJoinWaiters()
 	empty := len(g.topics[t.id]) == 0
 	if empty {
 		delete(g.topics, t.id)
@@ -431,6 +436,24 @@ func (g *Gossip) connect(ctx context.Context, peer PeerID, addr netaddr.Endpoint
 	return nil
 }
 
+// joinWaiter returns a channel closed on the next neighbor-set change. Callers
+// must take it before reading the neighbor set, or they can miss the wakeup for
+// a change that lands between the read and the wait. g.mu must be held.
+func (g *Gossip) joinWaiter() chan struct{} {
+	if g.joinWait == nil {
+		g.joinWait = make(chan struct{})
+	}
+	return g.joinWait
+}
+
+// wakeJoinWaiters wakes every Joined caller. g.mu must be held.
+func (g *Gossip) wakeJoinWaiters() {
+	if g.joinWait != nil {
+		close(g.joinWait)
+		g.joinWait = nil
+	}
+}
+
 func (g *Gossip) emit(topic TopicID, ev gossipproto.TopicEvent) {
 	event, ok := publicEvent(ev)
 	if !ok {
@@ -443,9 +466,11 @@ func (g *Gossip) emit(topic TopicID, ev gossipproto.TopicEvent) {
 			g.neighbors[topic] = make(map[PeerID]struct{})
 		}
 		g.neighbors[topic][ev.Peer] = struct{}{}
+		g.wakeJoinWaiters()
 	} else if ev.Kind == gossipproto.TopicNeighborDown {
 		g.metrics.neighborDown.Add(1)
 		delete(g.neighbors[topic], ev.Peer)
+		g.wakeJoinWaiters()
 	}
 	subs := make([]*Topic, 0, len(g.topics[topic]))
 	for t := range g.topics[topic] {
@@ -597,7 +622,9 @@ func (s *Sender) JoinPeers(ctx context.Context, peers []netaddr.EndpointAddr) er
 	return s.topic.JoinPeers(ctx, peers)
 }
 
-// Joined waits until the topic has at least one direct neighbor.
+// Joined waits until the topic has at least one direct neighbor. It observes
+// the neighbor set, not the event stream, so it can run alongside
+// [Topic.Events].
 func (t *Topic) Joined(ctx context.Context) error {
 	_, r := t.Split()
 	return r.Joined(ctx)
@@ -650,24 +677,31 @@ func (r *Receiver) Events() iter.Seq2[Event, error] {
 }
 
 // Joined waits until the receiver's topic has at least one direct neighbor.
+//
+// Joined observes the topic's neighbor set, not its event stream, so it can run
+// alongside [Receiver.Events] without either one taking the other's events.
 func (r *Receiver) Joined(ctx context.Context) error {
-	if r == nil || r.topic == nil {
+	if r == nil || r.topic == nil || r.topic.g == nil {
 		return errors.New("gossip: nil receiver")
 	}
-	if r.IsJoined() {
-		return nil
-	}
+	g := r.topic.g
 	for {
+		// Take the waiter before reading the state it reports on, so a
+		// neighbor arriving in between wakes this call instead of being
+		// missed until the next change.
+		g.mu.Lock()
+		wait := g.joinWaiter()
+		g.mu.Unlock()
+		if r.IsJoined() {
+			return nil
+		}
+		if r.topic.isClosed() {
+			return errors.New("gossip: topic closed")
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case ev, ok := <-r.topic.events:
-			if !ok {
-				return errors.New("gossip: topic closed")
-			}
-			if ev.Kind == NeighborUp || r.IsJoined() {
-				return nil
-			}
+		case <-wait:
 		}
 	}
 }

--- a/gossip/topic_internal_test.go
+++ b/gossip/topic_internal_test.go
@@ -2,19 +2,46 @@ package gossip
 
 import "testing"
 
-func TestTopicLaggedClosesSubscriber(t *testing.T) {
-	topic := &Topic{events: make(chan Event, 1)}
+// TestTopicLaggedReportsGapAndKeepsStream checks that a subscriber that falls
+// behind loses the dropped events but keeps the stream: the gap is reported
+// once, as a Lagged event, and delivery resumes.
+func TestTopicLaggedReportsGapAndKeepsStream(t *testing.T) {
+	topic := &Topic{events: make(chan Event, 2)}
 	topic.sendEvent(Event{Kind: NeighborUp})
-	topic.sendEvent(Event{Kind: Received})
+	topic.sendEvent(Event{Kind: NeighborUp})
+	topic.sendEvent(Event{Kind: Received})     // no room: dropped
+	topic.sendEvent(Event{Kind: NeighborDown}) // no room: dropped
 
-	ev, ok := <-topic.events
-	if !ok {
-		t.Fatal("events closed before Lagged")
+	if got := (<-topic.events).Kind; got != NeighborUp {
+		t.Fatalf("first event = %v, want NeighborUp", got)
 	}
+	if got := (<-topic.events).Kind; got != NeighborUp {
+		t.Fatalf("second event = %v, want NeighborUp", got)
+	}
+	if topic.isClosed() {
+		t.Fatal("topic closed by a dropped event")
+	}
+
+	topic.sendEvent(Event{Kind: Received})
+	ev := <-topic.events
 	if ev.Kind != Lagged {
-		t.Fatalf("event = %v, want Lagged", ev.Kind)
+		t.Fatalf("event after gap = %v, want Lagged", ev.Kind)
 	}
+	if ev.Dropped != 2 {
+		t.Fatalf("Lagged Dropped = %d, want 2", ev.Dropped)
+	}
+	if got := (<-topic.events).Kind; got != Received {
+		t.Fatalf("event after Lagged = %v, want Received", got)
+	}
+
+	// One gap reports once: the stream is caught up again.
+	topic.sendEvent(Event{Kind: NeighborDown})
+	if got := (<-topic.events).Kind; got != NeighborDown {
+		t.Fatalf("next event = %v, want NeighborDown", got)
+	}
+
+	topic.closeEvents()
 	if _, ok := <-topic.events; ok {
-		t.Fatal("events still open after Lagged")
+		t.Fatal("events still open after closeEvents")
 	}
 }


### PR DESCRIPTION
Keeps the stream open across a lagging subscriber, waits for a join on the neighbor set rather than the event queue, and documents when the stream starts.