### PR TITLE
relayserver: restore New's v0.1.0 signature

### DIFF
--- a/iroh/relay_echo_test.go
+++ b/iroh/relay_echo_test.go
@@ -17,7 +17,7 @@ type echoRelayServer struct{ ts *httptest.Server }
 
 func newEchoRelayServer(t testing.TB, opts ...relayserver.Option) echoRelayServer {
 	t.Helper()
-	ts := httptest.NewServer(relayserver.New(opts...))
+	ts := httptest.NewServer(relayserver.NewWithOptions(opts...))
 	t.Cleanup(ts.Close)
 	return echoRelayServer{ts: ts}
 }

--- a/relayserver/server.go
+++ b/relayserver/server.go
@@ -63,8 +63,12 @@ func WithClientRate(bytesPerSecond int64) Option {
 	return func(s *Server) { s.clientRate = bytesPerSecond }
 }
 
-// New returns a relay server.
-func New(opts ...Option) *Server {
+// New returns a relay server with default settings.
+// Use [NewWithOptions] to configure it.
+func New() *Server { return NewWithOptions() }
+
+// NewWithOptions returns a relay server configured by opts.
+func NewWithOptions(opts ...Option) *Server {
 	s := &Server{
 		clients:          make(map[key.EndpointID]*session),
 		establishTimeout: defaultEstablishTimeout,


### PR DESCRIPTION
New became variadic when options were added, changing its type. Restores New and moves the options form to NewWithOptions.