### PR TITLE
iroh: address lookup, IPv4 bind, and router dispatch fixes

### DIFF
--- a/internal/socket/custom.go
+++ b/internal/socket/custom.go
@@ -27,9 +27,15 @@ type Packet struct {
 // intentionally small: the transport owns its wire format and reports datagrams
 // as iroh custom addresses for the magic socket to map into qng paths.
 type CustomTransport interface {
-	// Serve runs the transport until ctx is done. Each received datagram should
-	// be passed to recv. recv reports false when the magic socket is shutting
-	// down or its receive queue is full.
+	// Serve runs the transport until ctx is done, passing each received
+	// datagram to recv.
+	//
+	// recv reports whether the datagram was taken. A false result means the
+	// datagram was dropped, most often because the receive queue was full
+	// under a burst; it is not a signal to stop. Serve must keep serving and
+	// return only when ctx is done, so `if !recv(d) { return }` tears the
+	// transport down on the first burst. Shutdown is reported through ctx
+	// alone, which is cancelled before the queue stops being drained.
 	Serve(ctx context.Context, recv func(CustomDatagram) bool)
 
 	// Send sends p to remote. local is nil when qng did not select a specific
@@ -42,7 +48,10 @@ type PacketTransport interface {
 	CustomTransport
 
 	// ServePackets runs the transport until ctx is done. Received packets are
-	// owned by the transport until their Free callback runs.
+	// owned by the transport until their Free callback runs. recv follows the
+	// same contract as [CustomTransport.Serve]: a false result means the packet
+	// was dropped, not that the transport should stop. A dropped packet's Free
+	// callback has already run.
 	ServePackets(ctx context.Context, recv func(Packet) bool)
 
 	// SendPacket sends p to remote. The transport must not retain p after the

--- a/internal/socket/custom_recv_test.go
+++ b/internal/socket/custom_recv_test.go
@@ -1,0 +1,78 @@
+package socket
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tmc/go-iroh/netaddr"
+)
+
+// burstTransport pushes n datagrams at recv without reading anything back and
+// records what recv reported, plus whether ctx was done at that moment.
+type burstTransport struct {
+	n       int
+	results []bool
+	ctxDone []bool
+	done    chan struct{}
+}
+
+func (t *burstTransport) Serve(ctx context.Context, recv func(CustomDatagram) bool) {
+	defer close(t.done)
+	for range t.n {
+		ok := recv(CustomDatagram{
+			Remote: netaddr.NewCustomAddr(7, []byte("peer")),
+			Data:   []byte("x"),
+		})
+		t.results = append(t.results, ok)
+		t.ctxDone = append(t.ctxDone, ctx.Err() != nil)
+	}
+}
+
+func (t *burstTransport) Send(netaddr.CustomAddr, *netaddr.CustomAddr, []byte) bool { return true }
+
+// TestCustomTransportRecvFalseIsNotShutdown pins the recv contract: under a
+// burst that outruns the receive queue, recv reports false while ctx is still
+// live. A transport that reads false as "shutting down" and returns would tear
+// itself down on the first burst; shutdown is reported through ctx alone.
+func TestCustomTransportRecvFalseIsNotShutdown(t *testing.T) {
+	const queue = 2
+	recvCh := make(chan recvBatch, queue)
+	fake := &burstTransport{n: queue + 4, done: make(chan struct{})}
+	ct := newCustomTransport(fake, recvCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ct.Serve(ctx)
+
+	select {
+	case <-fake.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return")
+	}
+
+	if got := len(fake.results); got != queue+4 {
+		t.Fatalf("recv called %d times, want %d", got, queue+4)
+	}
+	for i := range queue {
+		if !fake.results[i] {
+			t.Errorf("recv %d = false, want true while the queue has room", i)
+		}
+	}
+	sawDrop := false
+	for i := queue; i < len(fake.results); i++ {
+		if fake.results[i] {
+			continue
+		}
+		sawDrop = true
+		if fake.ctxDone[i] {
+			t.Errorf("recv %d reported false with ctx already done", i)
+		}
+	}
+	if !sawDrop {
+		t.Fatal("no datagram was dropped; the queue never filled")
+	}
+	if len(recvCh) != queue {
+		t.Errorf("queued %d datagrams, want %d", len(recvCh), queue)
+	}
+}

--- a/iroh/addresslookup.go
+++ b/iroh/addresslookup.go
@@ -42,7 +42,8 @@ func (f AddressPublisherFunc) Publish(data dns.EndpointData) {
 type AddressResolver interface {
 	// Resolve looks up addressing information for id. It returns a sequence of
 	// discovered [Item] values and per-service errors. Cancel ctx to stop
-	// pending work.
+	// pending work. Implementations should return an empty sequence rather
+	// than nil when there is nothing to report; callers must tolerate nil.
 	Resolve(ctx context.Context, id key.EndpointID) iter.Seq2[Item, error]
 }
 
@@ -297,6 +298,9 @@ func (s *AddressLookupServices) Resolve(ctx context.Context, id key.EndpointID) 
 		merged := make(chan lookupResult)
 		for _, resolver := range resolvers {
 			seq := resolver.Resolve(iterCtx, id)
+			if seq == nil {
+				continue
+			}
 			wg.Add(1)
 			go func(seq iter.Seq2[Item, error]) {
 				defer wg.Done()

--- a/iroh/addresslookup.go
+++ b/iroh/addresslookup.go
@@ -172,7 +172,14 @@ func RelayOnlyFilter(addrs []netaddr.TransportAddr) []netaddr.TransportAddr {
 	return out
 }
 
-// IPOnlyFilter keeps only direct IP and custom addresses, dropping relays.
+// IPOnlyFilter drops relay addresses and keeps everything else. Despite the
+// name it is not an IP allowlist: [netaddr.CustomAddr] transport addresses are
+// kept too, because IPOnlyFilter is defined as the exact complement of
+// [RelayOnlyFilter].
+//
+// A caller filtering for privacy should read this as "no relays". To publish
+// nothing but IP addresses, write a filter that tests for [netaddr.IPAddr]
+// positively.
 func IPOnlyFilter(addrs []netaddr.TransportAddr) []netaddr.TransportAddr {
 	out := make([]netaddr.TransportAddr, 0, len(addrs))
 	for _, a := range addrs {

--- a/iroh/addresslookup_memory.go
+++ b/iroh/addresslookup_memory.go
@@ -113,13 +113,14 @@ func (m *MemoryLookup) RemoveEndpointInfo(id key.EndpointID) (dns.EndpointInfo, 
 	return dns.EndpointInfo{ID: id, Data: info.data}, true
 }
 
-// Resolve returns the stored info for id, or nil if there is no entry.
+// Resolve returns the stored info for id, or an empty sequence if there is no
+// entry.
 func (m *MemoryLookup) Resolve(ctx context.Context, id key.EndpointID) iter.Seq2[Item, error] {
 	m.mu.RLock()
 	info, ok := m.endpoints[id]
 	m.mu.RUnlock()
 	if !ok {
-		return nil
+		return func(yield func(Item, error) bool) {}
 	}
 	lastUpdated := uint64(info.lastUpdated.UnixMicro())
 	item := NewItem(dns.EndpointInfo{ID: id, Data: info.data}, m.provenance, &lastUpdated)

--- a/iroh/addresslookup_test.go
+++ b/iroh/addresslookup_test.go
@@ -60,8 +60,12 @@ func TestMemoryLookup(t *testing.T) {
 	if _, ok := m.GetEndpointInfo(id); ok {
 		t.Fatal("empty lookup returned an entry")
 	}
-	if ch := m.Resolve(context.Background(), id); ch != nil {
-		t.Fatal("Resolve of unknown id should return nil channel")
+	seq := m.Resolve(context.Background(), id)
+	if seq == nil {
+		t.Fatal("Resolve of unknown id returned a nil sequence")
+	}
+	if got := drain(seq); len(got) != 0 {
+		t.Fatalf("Resolve of unknown id = %+v, want no results", got)
 	}
 
 	addr := netaddr.NewEndpointAddr(id).WithRelayURL(relayURL(t, "https://relay.example/"))
@@ -600,5 +604,47 @@ func TestFilteredAddressPublisher(t *testing.T) {
 	}
 	if len(rec.published[0].IPAddrs()) != 1 {
 		t.Errorf("IP address should be kept, got %v", rec.published[0].IPAddrs())
+	}
+}
+
+// nilLookup is an AddressResolver that reports nothing by returning a nil
+// sequence, the shape [MemoryLookup] used before it returned an empty one.
+type nilLookup struct{}
+
+func (nilLookup) Resolve(context.Context, key.EndpointID) iter.Seq2[Item, error] { return nil }
+
+// TestServicesResolveNilSequence checks that a resolver returning a nil
+// sequence is skipped rather than ranged over, which panicked.
+func TestServicesResolveNilSequence(t *testing.T) {
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := sk.Public().EndpointID()
+	info := endpointInfoWithIP(id, netip.MustParseAddrPort("192.0.2.1:1234"))
+
+	var svcs AddressLookupServices
+	svcs.AddResolver(nilLookup{})
+	svcs.AddResolver(staticLookup{provenance: "ok", info: &info})
+
+	var got bool
+	for item, err := range svcs.Resolve(context.Background(), id) {
+		if err == nil && item.EndpointID().Equal(id) {
+			got = true
+		}
+	}
+	if !got {
+		t.Error("expected the second resolver's item, got none")
+	}
+
+	// A nil-only set of resolvers must report ErrNoResults, not hang or panic.
+	var only AddressLookupServices
+	only.AddResolver(nilLookup{})
+	results := drain(only.Resolve(context.Background(), id))
+	if len(results) == 0 {
+		t.Fatal("nil-only resolve produced no results, want ErrNoResults")
+	}
+	if last := results[len(results)-1]; !errors.Is(last.err, ErrNoResults) {
+		t.Fatalf("final result = %+v, want ErrNoResults", last)
 	}
 }

--- a/iroh/addresslookup_test.go
+++ b/iroh/addresslookup_test.go
@@ -585,6 +585,28 @@ func TestServicesAddPublishesHistorical(t *testing.T) {
 	}
 }
 
+// TestAddrFilterComplement pins IPOnlyFilter as the exact complement of
+// RelayOnlyFilter: it keeps custom transport addresses, which its name does not
+// suggest, and together the two partition the address set.
+func TestAddrFilterComplement(t *testing.T) {
+	addrs := []netaddr.TransportAddr{
+		netaddr.RelayAddr{URL: relayURL(t, "https://relay.example/")},
+		netaddr.IPAddr{Addr: netip.MustParseAddrPort("1.2.3.4:1")},
+		netaddr.NewCustomAddr(7, []byte{0xde, 0xad}),
+	}
+	relays := RelayOnlyFilter(addrs)
+	rest := IPOnlyFilter(addrs)
+	if len(relays) != 1 || len(rest) != 2 {
+		t.Fatalf("RelayOnlyFilter kept %d, IPOnlyFilter kept %d; want 1 and 2", len(relays), len(rest))
+	}
+	if _, ok := rest[1].(netaddr.CustomAddr); !ok {
+		t.Errorf("IPOnlyFilter dropped the custom address: %v", rest)
+	}
+	if got, want := len(relays)+len(rest), len(addrs); got != want {
+		t.Errorf("filters kept %d addresses in total, want %d", got, want)
+	}
+}
+
 func TestFilteredAddressPublisher(t *testing.T) {
 	rec := &recordingLookup{}
 	f := NewFilteredAddressPublisher(rec, IPOnlyFilter)

--- a/iroh/bind_udp.go
+++ b/iroh/bind_udp.go
@@ -11,5 +11,14 @@ func bindPacketConn(c config, bind netip.AddrPort) (*net.UDPConn, error) {
 	if c.disableIP {
 		return nil, nil
 	}
-	return net.ListenUDP("udp", net.UDPAddrFromAddrPort(bind))
+	// Bind an IPv4 address on an IPv4 socket. net.ListenUDP("udp", ...) gives
+	// 0.0.0.0 a dual-stack socket whose LocalAddr reports [::], so a caller
+	// that asked for IPv4 would get an IPv6 address back from
+	// Endpoint.LocalAddr. The default bind address is the IPv6 unspecified
+	// address, so the default socket stays dual-stack.
+	network := "udp"
+	if bind.Addr().Is4() {
+		network = "udp4"
+	}
+	return net.ListenUDP(network, net.UDPAddrFromAddrPort(bind))
 }

--- a/iroh/custom.go
+++ b/iroh/custom.go
@@ -19,9 +19,15 @@ type CustomDatagram struct {
 // Implementations own their wire format and exchange datagrams using
 // [netaddr.CustomAddr] values advertised in endpoint addresses.
 type CustomTransport interface {
-	// Serve runs the transport until ctx is done. Each received datagram should
-	// be passed to recv. recv reports false when the endpoint is shutting down or
-	// its receive queue is full.
+	// Serve runs the transport until ctx is done, passing each received
+	// datagram to recv.
+	//
+	// recv reports whether the datagram was taken. A false result means the
+	// datagram was dropped, most often because the receive queue was full
+	// under a burst; it is not a signal to stop. Serve must keep serving and
+	// return only when ctx is done, so `if !recv(d) { return }` tears the
+	// transport down on the first burst. Shutdown is reported through ctx
+	// alone, which is cancelled before the queue stops being drained.
 	Serve(ctx context.Context, recv func(CustomDatagram) bool)
 
 	// Send sends p to remote. local is nil when qng did not select a specific

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -264,9 +264,10 @@ func WithRelayFirstDial() Option {
 
 // WithAddressLookup sets the address-lookup services the endpoint uses to
 // resolve additional addresses for a remote endpoint (pkarr, DNS, in-memory).
-// The per-remote state machine consults them through its resolve hook. When
+// The per-remote state machine consults them through its resolve hook, and
+// [Endpoint.Connect] consults them to seed a dial by endpoint ID alone. When
 // unset, the endpoint does no lookup-driven address resolution and connects only
-// to the addresses passed to [Endpoint.Connect].
+// to the addresses passed to Connect.
 func WithAddressLookup(s *AddressLookupServices) Option {
 	return func(c *config) error {
 		c.lookup = s
@@ -1196,6 +1197,14 @@ var ErrConnClosedDuringHandshake = errors.New("iroh: connection closed during ha
 // (if relays are enabled) the relay URLs in addr. A relay path carries the QUIC
 // handshake over a relay mapped address that routes through the relay transport.
 //
+// When addr carries no usable address at all - a dial by endpoint ID alone -
+// Connect resolves one through the services given to [WithAddressLookup] and
+// dials the first answer that has any. Such a call waits on the lookup, so it
+// blocks where it would once have failed at once; it still returns
+// [ErrNoAddress] when no service is configured or none answers before the
+// deadline. Connect does not consult the lookup when addr already has an
+// address, even if none of them work.
+//
 // Connect blocks until the handshake completes and the peer identity is
 // verified. To send 0-RTT early data before the handshake completes, use
 // [Endpoint.ConnectEarly] and [Connecting.Into0RTT].
@@ -1266,6 +1275,14 @@ func (e *Endpoint) connectEarly(ctx context.Context, addr netaddr.EndpointAddr, 
 	}
 
 	dials := e.dialTargets(addr)
+	if len(dials) == 0 {
+		// Nothing to dial: this is the bare-ID case WithAddressLookup exists
+		// for. Ask the lookup services for a path before giving up.
+		if found, ok := e.lookupAddr(ctx, addr); ok {
+			addr = found
+			dials = e.dialTargets(addr)
+		}
+	}
 	if len(dials) == 0 {
 		return nil, ErrNoAddress
 	}
@@ -1634,6 +1651,32 @@ func (e *Endpoint) removeStableIDWhenClosed(qc *quic.Conn) {
 	e.mu.Lock()
 	delete(e.stableIDs, qc)
 	e.mu.Unlock()
+}
+
+// lookupAddr asks the endpoint's address-lookup services for addresses for
+// addr.ID and returns addr merged with the first answer that carries any,
+// reporting whether it found one. It is bounded by ctx, and stops at the first
+// usable answer: a lookup is a way to start dialing, not a way to collect every
+// path a peer might have. "Usable" means the answer carried addresses, not that
+// this endpoint can dial them: a relay-only answer with relays disabled, or an
+// IP-only answer with direct paths disabled, ends the search and then leaves
+// dialTargets empty, so the dial fails with [ErrNoAddress] as it would have
+// without the lookup.
+func (e *Endpoint) lookupAddr(ctx context.Context, addr netaddr.EndpointAddr) (netaddr.EndpointAddr, bool) {
+	if e.lookup == nil || addr.ID.IsZero() {
+		return addr, false
+	}
+	for item, err := range e.lookup.Resolve(ctx, addr.ID) {
+		if err != nil {
+			continue
+		}
+		found := item.Addr()
+		if !found.ID.Equal(addr.ID) || found.IsEmpty() {
+			continue
+		}
+		return addr.WithAddrs(found.Addrs()...), true
+	}
+	return addr, false
 }
 
 // resolveFunc returns the address-lookup hook the RemoteMap actors use to

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -32,6 +32,9 @@ import (
 type Endpoint struct {
 	secretKey key.SecretKey
 	alpns     []string
+	// bindALPNs is the ALPN set WithALPNs configured at Bind. It is fixed for
+	// the endpoint's lifetime, unlike alpns, which SetALPNs replaces.
+	bindALPNs []string
 
 	udp          *net.UDPConn
 	sock         *socket.Socket
@@ -488,6 +491,7 @@ func Bind(ctx context.Context, opts ...Option) (*Endpoint, error) {
 	ep := &Endpoint{
 		secretKey: c.secretKey,
 		alpns:     slices.Clone(c.alpns),
+		bindALPNs: slices.Clone(c.alpns),
 		udp:       udp,
 		sock:      sock,
 		magic:     magic,
@@ -651,6 +655,13 @@ func (e *Endpoint) startListener() error {
 // byte string represented as a Go string; see [WithALPNs].
 func (e *Endpoint) SetALPNs(alpns []string) error {
 	return e.setALPNs(alpns, acceptOwnerNone)
+}
+
+// boundALPNs returns the ALPNs [WithALPNs] configured at [Bind], not the set
+// the endpoint accepts now: [SetALPNs] and [Router] both replace that set by
+// design, so the current one says nothing about the caller's intent.
+func (e *Endpoint) boundALPNs() []string {
+	return slices.Clone(e.bindALPNs)
 }
 
 func (e *Endpoint) setALPNs(alpns []string, allowedOwner acceptOwner) error {

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -8,6 +8,8 @@ import (
 	"iter"
 	"net"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"slices"
 	"sync"
 	"time"
@@ -18,6 +20,7 @@ import (
 	"github.com/tmc/go-iroh/internal/portmapper"
 	quic "github.com/tmc/go-iroh/internal/qng"
 	"github.com/tmc/go-iroh/internal/qng/qlog"
+	"github.com/tmc/go-iroh/internal/qng/qlogwriter"
 	"github.com/tmc/go-iroh/internal/socket"
 	"github.com/tmc/go-iroh/key"
 	"github.com/tmc/go-iroh/netaddr"
@@ -110,6 +113,7 @@ type config struct {
 	natPMPGateway   netip.Addr
 	natPMPPort      uint16
 	keyLogWriter    io.Writer
+	qlogSink        func(context.Context, QLOGConnection) io.WriteCloser
 	keyExchange     KeyExchangePolicy
 	transportConfig *QUICTransportConfig
 	pathSelector    socket.PathSelector
@@ -340,6 +344,73 @@ func WithKeyLogWriter(w io.Writer) Option {
 	}
 }
 
+// QLOGConnection identifies the connection a qlog trace belongs to. It is
+// passed to the sink installed by [WithQLOG].
+type QLOGConnection struct {
+	// ConnectionID is the original destination connection ID, lowercase hex.
+	// It is the stem QLOGDIR uses for the trace's file name, so its exact
+	// form is part of this API.
+	ConnectionID string
+	// Client reports whether this endpoint dialed the connection.
+	Client bool
+}
+
+// WithQLOG sends this endpoint's qlog traces to sink instead of to the
+// directory named by the QLOGDIR environment variable. sink is called once per
+// connection, before the handshake; returning nil traces that connection not at
+// all. The returned writer receives one JSON-seq qlog trace and is closed once,
+// when the connection ends.
+//
+// The environment variable is process-wide, so several endpoints in one process
+// interleave their traces in one directory keyed only by connection id. A sink
+// is per-endpoint: give each one its own directory with [QLOGDir], or its own
+// io.WriteCloser to route traces anywhere. QLOGDIR still applies to endpoints
+// that install no sink.
+func WithQLOG(sink func(context.Context, QLOGConnection) io.WriteCloser) Option {
+	return func(c *config) error {
+		c.qlogSink = sink
+		return nil
+	}
+}
+
+// QLOGDir returns a [WithQLOG] sink that writes <connection id>_<client|server>.sqlog
+// files in dir, the layout QLOGDIR produces. It creates dir if needed, and
+// traces nothing it cannot write.
+func QLOGDir(dir string) func(context.Context, QLOGConnection) io.WriteCloser {
+	return func(_ context.Context, conn QLOGConnection) io.WriteCloser {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil
+		}
+		side := "server"
+		if conn.Client {
+			side = "client"
+		}
+		f, err := os.Create(filepath.Join(dir, fmt.Sprintf("%s_%s.sqlog", conn.ConnectionID, side)))
+		if err != nil {
+			return nil
+		}
+		return f
+	}
+}
+
+// qlogTracer adapts a WithQLOG sink to the QUIC stack's connection tracer,
+// keeping qlogwriter's event model out of the iroh API. Without a sink the
+// QLOGDIR tracer is used, exactly as before.
+func qlogTracer(sink func(context.Context, QLOGConnection) io.WriteCloser) func(context.Context, bool, quic.ConnectionID) qlogwriter.Trace {
+	if sink == nil {
+		return qlog.DefaultConnectionTracer
+	}
+	return func(ctx context.Context, isClient bool, connID quic.ConnectionID) qlogwriter.Trace {
+		w := sink(ctx, QLOGConnection{ConnectionID: connID.String(), Client: isClient})
+		if w == nil {
+			return nil
+		}
+		trace := qlogwriter.NewConnectionFileSeq(w, isClient, connID, []string{qlog.EventSchema})
+		go trace.Run()
+		return trace
+	}
+}
+
 // WithKeyExchangePolicy selects the TLS key-exchange groups used for direct
 // peer connections. The zero policy keeps the package default.
 //
@@ -437,7 +508,7 @@ func Bind(ctx context.Context, opts ...Option) (*Endpoint, error) {
 		EnableDatagrams:                true,
 		InitialMaxPathID:               initialMaxPathID(),
 		MaxRemoteNATTraversalAddresses: maxRemoteNATTraversalAddresses(),
-		Tracer:                         qlog.DefaultConnectionTracer,
+		Tracer:                         qlogTracer(c.qlogSink),
 		// Accept 0-RTT early data on incoming connections that resume a prior
 		// session. Allow0RTT is ignored for dialed connections, so sharing this
 		// config with Connect is safe. Mirrors the Rust server enabling early

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -338,6 +338,10 @@ func WithKeyLogWriter(w io.Writer) Option {
 
 // WithKeyExchangePolicy selects the TLS key-exchange groups used for direct
 // peer connections. The zero policy keeps the package default.
+//
+// Both peers must offer a group the other accepts. A dial to a peer with no
+// group in common fails with [ErrTLSHandshakeFailure], whichever side's policy
+// is the narrower one.
 func WithKeyExchangePolicy(policy KeyExchangePolicy) Option {
 	return func(c *config) error {
 		if !policy.valid() {
@@ -1298,7 +1302,7 @@ func (e *Endpoint) connectEarly(ctx context.Context, addr netaddr.EndpointAddr, 
 		}
 		return &Connecting{ep: e, qc: qc, remoteID: addr.ID, addr: addr, alpn: alpn}, nil
 	}
-	return nil, fmt.Errorf("iroh: connect to %s: %w", addr.ID, firstErr)
+	return nil, fmt.Errorf("iroh: connect to %s: %w", addr.ID, tlsHandshakeFailure(firstErr))
 }
 
 // Dial dials addr, negotiates alpn, opens a bidirectional stream, and returns it

--- a/iroh/endpoint.go
+++ b/iroh/endpoint.go
@@ -184,7 +184,12 @@ func WithSourceAddressValidation(f func(net.Addr) bool) Option {
 }
 
 // WithBindAddr sets the local UDP address to bind. The default is an
-// OS-assigned port on the unspecified address.
+// OS-assigned port on the IPv6 unspecified address, which the OS gives a
+// dual-stack socket.
+//
+// An IPv4 address, 0.0.0.0 included, binds an IPv4-only socket, so the endpoint
+// reaches IPv4 peers only and [Endpoint.LocalAddr] reports the family that was
+// asked for. Pass an IPv6 address, or nothing, for dual-stack.
 func WithBindAddr(addr netip.AddrPort) Option {
 	return func(c *config) error {
 		c.bindAddr = addr
@@ -675,7 +680,9 @@ func (e *Endpoint) ID() key.EndpointID { return e.secretKey.Public().EndpointID(
 // SecretKey returns the endpoint's secret key.
 func (e *Endpoint) SecretKey() key.SecretKey { return e.secretKey }
 
-// LocalAddr returns the bound UDP address.
+// LocalAddr returns the bound UDP address, as reported by the socket. For a
+// dual-stack socket that is an IPv6 address whatever [WithBindAddr] was given;
+// see WithBindAddr for which bind addresses are dual-stack.
 func (e *Endpoint) LocalAddr() netip.AddrPort {
 	if e.udp == nil {
 		return netip.AddrPort{}

--- a/iroh/endpoint_more_test.go
+++ b/iroh/endpoint_more_test.go
@@ -142,6 +142,34 @@ func (t *endpointFakeCustomTransport) lastSend() (endpointFakeCustomSend, bool) 
 
 // TestEndpointSecretKey verifies SecretKey returns the configured key and that
 // its public half matches the endpoint id.
+// TestBindPacketConnFamily pins that the socket family follows the bind
+// address. net.ListenUDP("udp", "0.0.0.0:0") returns a dual-stack socket whose
+// LocalAddr reports [::], which made Endpoint.LocalAddr contradict WithBindAddr.
+func TestBindPacketConnFamily(t *testing.T) {
+	tests := []struct {
+		name    string
+		bind    string
+		wantIs4 bool
+	}{
+		{"ipv4 unspecified", "0.0.0.0:0", true},
+		{"ipv4 loopback", "127.0.0.1:0", true},
+		{"ipv6 unspecified is dual-stack", "[::]:0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := bindPacketConn(config{}, netip.MustParseAddrPort(tt.bind))
+			if err != nil {
+				t.Fatalf("bindPacketConn(%s): %v", tt.bind, err)
+			}
+			defer conn.Close()
+			got := conn.LocalAddr().(*net.UDPAddr).AddrPort().Addr()
+			if got.Is4() != tt.wantIs4 {
+				t.Errorf("bind %s: LocalAddr %v, Is4 = %v, want %v", tt.bind, got, got.Is4(), tt.wantIs4)
+			}
+		})
+	}
+}
+
 func TestEndpointSecretKey(t *testing.T) {
 	ctx := context.Background()
 	sk, _ := key.GenerateSecretKey()

--- a/iroh/endpoint_more_test.go
+++ b/iroh/endpoint_more_test.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
+	"io"
 	"net"
 	"net/netip"
+	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1587,5 +1591,240 @@ func TestEndpointRemoteInfoNil(t *testing.T) {
 	id, _ := key.GenerateSecretKey()
 	if _, ok := ep.RemoteInfo(id.Public().EndpointID()); ok {
 		t.Fatal("nil Endpoint RemoteInfo = true, want false")
+	}
+}
+
+// countingSink is a WithQLOG sink that records what it was asked for and how
+// often each writer was closed.
+type countingSink struct {
+	mu     sync.Mutex
+	conns  []QLOGConnection
+	closes map[string]int
+	bufs   map[string]*bytes.Buffer
+	nilFor func(QLOGConnection) bool
+}
+
+type countingSinkWriter struct {
+	s  *countingSink
+	id string
+}
+
+func (w countingSinkWriter) Write(p []byte) (int, error) {
+	w.s.mu.Lock()
+	defer w.s.mu.Unlock()
+	return w.s.bufs[w.id].Write(p)
+}
+
+func (w countingSinkWriter) Close() error {
+	w.s.mu.Lock()
+	defer w.s.mu.Unlock()
+	w.s.closes[w.id]++
+	return nil
+}
+
+func (s *countingSink) sink(_ context.Context, conn QLOGConnection) io.WriteCloser {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conns = append(s.conns, conn)
+	if s.nilFor != nil && s.nilFor(conn) {
+		return nil
+	}
+	if s.bufs == nil {
+		s.bufs = make(map[string]*bytes.Buffer)
+		s.closes = make(map[string]int)
+	}
+	id := conn.ConnectionID
+	s.bufs[id] = &bytes.Buffer{}
+	return countingSinkWriter{s: s, id: id}
+}
+
+func (s *countingSink) snapshot() ([]QLOGConnection, map[string]int, map[string]int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sizes := make(map[string]int, len(s.bufs))
+	for id, buf := range s.bufs {
+		sizes[id] = buf.Len()
+	}
+	closes := make(map[string]int, len(s.closes))
+	for id, n := range s.closes {
+		closes[id] = n
+	}
+	return slices.Clone(s.conns), sizes, closes
+}
+
+// TestWithQLOGSink checks that a per-endpoint qlog sink receives that
+// endpoint's traces and nobody else's, that its connection ids are hex, and
+// that each writer is closed exactly once when the endpoint shuts down without
+// closing the connection first.
+func TestWithQLOGSink(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const alpn = "iroh-qlog-sink/0"
+	serverSink := &countingSink{}
+	server, err := Bind(ctx,
+		WithALPNs(alpn),
+		WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)),
+		WithQLOG(serverSink.sink),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := make(chan error, 1)
+	go func() {
+		_, err := server.Accept(ctx)
+		accepted <- err
+	}()
+
+	clientSink := &countingSink{}
+	client, err := Bind(ctx,
+		WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)),
+		WithQLOG(clientSink.sink),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := client.Connect(ctx, netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr()), alpn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-accepted; err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	_ = conn
+
+	clientConns, clientSizes, _ := clientSink.snapshot()
+	if len(clientConns) != 1 {
+		t.Fatalf("client sink called %d times, want 1", len(clientConns))
+	}
+	if !clientConns[0].Client {
+		t.Error("client sink saw Client = false")
+	}
+	if _, err := hex.DecodeString(clientConns[0].ConnectionID); err != nil {
+		t.Errorf("connection id %q is not hex: %v", clientConns[0].ConnectionID, err)
+	}
+	if n := clientSizes[clientConns[0].ConnectionID]; n == 0 {
+		t.Error("client sink writer received no trace")
+	}
+	serverConns, _, _ := serverSink.snapshot()
+	if len(serverConns) != 1 {
+		t.Fatalf("server sink called %d times, want 1", len(serverConns))
+	}
+	if serverConns[0].Client {
+		t.Error("server sink saw Client = true")
+	}
+	// Each endpoint's traces go to its own sink: the two sides of one
+	// connection share an original destination connection id.
+	if serverConns[0].ConnectionID != clientConns[0].ConnectionID {
+		t.Errorf("server odcid %q, client odcid %q, want the same", serverConns[0].ConnectionID, clientConns[0].ConnectionID)
+	}
+
+	// Shut the endpoints down without closing the connection first.
+	server.Shutdown(ctx)
+	client.Shutdown(ctx)
+	for _, s := range []*countingSink{clientSink, serverSink} {
+		conns, _, _ := s.snapshot()
+		id := conns[0].ConnectionID
+		deadline := time.Now().Add(10 * time.Second)
+		for {
+			_, _, closes := s.snapshot()
+			if closes[id] > 0 {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("qlog writer for %s was never closed", id)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		// Once is once: give a second close time to arrive before asserting.
+		time.Sleep(200 * time.Millisecond)
+		if _, _, closes := s.snapshot(); closes[id] != 1 {
+			t.Errorf("qlog writer for %s closed %d times, want exactly 1", id, closes[id])
+		}
+	}
+}
+
+// TestWithQLOGSinkNil checks that a sink returning nil traces nothing and does
+// not break the connection.
+func TestWithQLOGSinkNil(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const alpn = "iroh-qlog-nil/0"
+	sink := &countingSink{nilFor: func(QLOGConnection) bool { return true }}
+	server, err := Bind(ctx, WithALPNs(alpn), WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithQLOG(sink.sink))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Shutdown(ctx)
+	accepted := make(chan error, 1)
+	go func() {
+		_, err := server.Accept(ctx)
+		accepted <- err
+	}()
+
+	client, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithQLOG(sink.sink))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown(ctx)
+
+	conn, err := client.Connect(ctx, netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr()), alpn)
+	if err != nil {
+		t.Fatalf("connect with a nil qlog sink: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+	if err := <-accepted; err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	conns, sizes, closes := sink.snapshot()
+	if len(conns) == 0 {
+		t.Fatal("sink was never called")
+	}
+	if len(sizes) != 0 || len(closes) != 0 {
+		t.Fatalf("a nil sink produced writers: sizes=%v closes=%v", sizes, closes)
+	}
+}
+
+// TestQLOGDir checks that the QLOGDir sink writes the file layout its doc
+// promises: <connection id>_<client|server>.sqlog under the given directory.
+func TestQLOGDir(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const alpn = "iroh-qlog-dir/0"
+	serverDir, clientDir := t.TempDir(), t.TempDir()
+	server, err := Bind(ctx, WithALPNs(alpn), WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithQLOG(QLOGDir(serverDir)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Shutdown(ctx)
+	go server.Accept(ctx)
+
+	client, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithQLOG(QLOGDir(clientDir)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown(ctx)
+
+	conn, err := client.Connect(ctx, netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr()), alpn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	for _, tc := range []struct{ dir, side string }{{clientDir, "client"}, {serverDir, "server"}} {
+		names, err := filepath.Glob(filepath.Join(tc.dir, "*_"+tc.side+".sqlog"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(names) != 1 {
+			t.Fatalf("%s traces = %v, want exactly one", tc.side, names)
+		}
+		stem := strings.TrimSuffix(filepath.Base(names[0]), "_"+tc.side+".sqlog")
+		if _, err := hex.DecodeString(stem); err != nil {
+			t.Errorf("trace name stem %q is not hex: %v", stem, err)
+		}
 	}
 }

--- a/iroh/endpoint_test.go
+++ b/iroh/endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net"
 	"net/netip"
 	"sync/atomic"
@@ -956,4 +957,97 @@ func TestEndpointNoAddress(t *testing.T) {
 	if err != ErrNoAddress {
 		t.Errorf("Connect(no addr) err = %v, want ErrNoAddress", err)
 	}
+}
+
+// TestConnectByIDUsesAddressLookup checks that a dial by endpoint ID alone
+// resolves through the configured address-lookup services, that the failure
+// mode without an answer is unchanged, and that a dial with an address does not
+// consult them.
+func TestConnectByIDUsesAddressLookup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const alpn = "iroh-lookup-dial/0"
+
+	newServer := func(t *testing.T) *Endpoint {
+		t.Helper()
+		server, err := Bind(ctx, WithALPNs(alpn), WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { server.Shutdown(ctx) })
+		go func() {
+			for {
+				conn, err := server.Accept(ctx)
+				if err != nil {
+					return
+				}
+				conn.CloseWithError(0, "")
+			}
+		}()
+		return server
+	}
+
+	t.Run("bare id resolves", func(t *testing.T) {
+		server := newServer(t)
+		lookup := NewMemoryLookup()
+		lookup.AddEndpointAddr(netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr()))
+
+		var services AddressLookupServices
+		services.AddResolver(lookup)
+		client, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithAddressLookup(&services))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Shutdown(ctx)
+
+		conn, err := client.Connect(ctx, netaddr.NewEndpointAddr(server.ID()), alpn)
+		if err != nil {
+			t.Fatalf("connect by id: %v", err)
+		}
+		defer conn.CloseWithError(0, "")
+		if !conn.RemoteID().Equal(server.ID()) {
+			t.Fatalf("remote id = %s, want %s", conn.RemoteID(), server.ID())
+		}
+	})
+
+	t.Run("no answer still returns ErrNoAddress", func(t *testing.T) {
+		var services AddressLookupServices
+		services.AddResolver(NewMemoryLookup())
+		client, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithAddressLookup(&services))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Shutdown(ctx)
+
+		other, _ := key.GenerateSecretKey()
+		if _, err := client.Connect(ctx, netaddr.NewEndpointAddr(other.Public().EndpointID()), alpn); err != ErrNoAddress {
+			t.Fatalf("connect with an empty lookup = %v, want ErrNoAddress", err)
+		}
+	})
+
+	// A dial that already has an address must not wait on the lookup. The
+	// per-remote state machine still consults it in the background, so the
+	// resolver is not counted; it is made to block instead, which fails the
+	// test by timeout if Connect starts waiting on it.
+	t.Run("address present does not wait on the lookup", func(t *testing.T) {
+		server := newServer(t)
+		var services AddressLookupServices
+		services.AddResolver(AddressResolverFunc(func(ctx context.Context, id key.EndpointID) iter.Seq2[Item, error] {
+			return func(yield func(Item, error) bool) { <-ctx.Done() }
+		}))
+		client, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)), WithAddressLookup(&services))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer client.Shutdown(ctx)
+
+		dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		conn, err := client.Connect(dialCtx, netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr()), alpn)
+		if err != nil {
+			t.Fatalf("connect with an address and a blocking lookup: %v", err)
+		}
+		conn.CloseWithError(0, "")
+	})
 }

--- a/iroh/errors.go
+++ b/iroh/errors.go
@@ -45,3 +45,47 @@ func AsApplicationError(err error) (*ApplicationError, bool) {
 		Remote: appErr.Remote,
 	}, true
 }
+
+// ErrTLSHandshakeFailure reports a QUIC handshake that ended in the TLS
+// "handshake_failure" alert (alert 40), which a peer sends when it finds no
+// acceptable set of handshake parameters. Between iroh endpoints the cause is a
+// key-exchange group mismatch: the two [KeyExchangePolicy] values have no group
+// in common, so neither side can complete the exchange. The cipher suite and
+// the raw-public-key signature algorithm are fixed by the protocol and never
+// differ between iroh peers; a peer running another implementation may send the
+// same alert for another reason.
+//
+// [Endpoint.Connect] and [Endpoint.Dial] wrap such a failure so it can be told
+// apart from other handshake failures without matching error text:
+//
+//	if _, err := ep.Connect(ctx, addr, alpn); errors.Is(err, iroh.ErrTLSHandshakeFailure) {
+//		// no key exchange group in common; see WithKeyExchangePolicy
+//	}
+//
+// The alert is symmetric: the dialer sees it whether its own policy or the
+// peer's was the narrower one.
+var ErrTLSHandshakeFailure = errors.New("iroh: tls handshake failure")
+
+// alertHandshakeFailure is the TLS handshake_failure alert (RFC 8446, B.2).
+const alertHandshakeFailure = 40
+
+// tlsHandshakeFailure joins err with [ErrTLSHandshakeFailure] when err carries a
+// QUIC CRYPTO_ERROR for the handshake_failure alert, and returns err unchanged
+// otherwise. The message is err's own, so only errors.Is sees the difference.
+func tlsHandshakeFailure(err error) error {
+	var te *quic.TransportError
+	if !errors.As(err, &te) || !te.ErrorCode.IsCryptoError() {
+		return err
+	}
+	if te.ErrorCode-0x100 != alertHandshakeFailure {
+		return err
+	}
+	return handshakeFailureError{err}
+}
+
+// handshakeFailureError adds [ErrTLSHandshakeFailure] to an error chain without
+// changing what the error says.
+type handshakeFailureError struct{ err error }
+
+func (e handshakeFailureError) Error() string   { return e.err.Error() }
+func (e handshakeFailureError) Unwrap() []error { return []error{ErrTLSHandshakeFailure, e.err} }

--- a/iroh/keyexchange_test.go
+++ b/iroh/keyexchange_test.go
@@ -2,10 +2,12 @@ package iroh
 
 import (
 	"context"
+	"errors"
 	"net/netip"
 	"testing"
 	"time"
 
+	"github.com/tmc/go-iroh/key"
 	"github.com/tmc/go-iroh/netaddr"
 )
 
@@ -68,22 +70,64 @@ func TestKeyExchangePolicyNegotiation(t *testing.T) {
 	}
 }
 
-func TestKeyExchangePQOnlyRefusesClassical(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	server, err := Bind(ctx, WithALPNs("iroh-kx-test/0"), WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")), WithKeyExchangePolicy(KeyExchangePQOnly))
-	if err != nil {
-		t.Fatal(err)
+// TestKeyExchangeMismatchIsReported checks that a dial refused for want of a
+// common key-exchange group is reported as ErrTLSHandshakeFailure, in both
+// directions: the alert reaches the dialer whether its own policy or the
+// server's is the narrower one.
+func TestKeyExchangeMismatchIsReported(t *testing.T) {
+	tests := []struct {
+		name           string
+		server, client KeyExchangePolicy
+	}{
+		{name: "pq only server", server: KeyExchangePQOnly, client: KeyExchangeClassical},
+		{name: "pq only client", server: KeyExchangeClassical, client: KeyExchangePQOnly},
 	}
-	defer server.Shutdown(context.Background())
-	client, err := Bind(ctx, WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")), WithKeyExchangePolicy(KeyExchangeClassical))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			server, err := Bind(ctx, WithALPNs("iroh-kx-test/0"), WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")), WithKeyExchangePolicy(tt.server))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer server.Shutdown(context.Background())
+			client, err := Bind(ctx, WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")), WithKeyExchangePolicy(tt.client))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Shutdown(context.Background())
+			addr := netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr())
+			_, err = client.Connect(ctx, addr, "iroh-kx-test/0")
+			if err == nil {
+				t.Fatal("connected despite incompatible key exchange policies")
+			}
+			if !errors.Is(err, ErrTLSHandshakeFailure) {
+				t.Errorf("Connect error = %v, want one matching ErrTLSHandshakeFailure", err)
+			}
+		})
+	}
+}
+
+// TestKeyExchangeMatchIsNotHandshakeFailure guards against ErrTLSHandshakeFailure
+// being attached to failures that are not TLS alerts.
+func TestKeyExchangeMatchIsNotHandshakeFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	client, err := Bind(ctx, WithBindAddr(netip.MustParseAddrPort("127.0.0.1:0")), WithKeyExchangePolicy(KeyExchangePQOnly))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer client.Shutdown(context.Background())
-	addr := netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr())
-	if _, err := client.Connect(ctx, addr, "iroh-kx-test/0"); err == nil {
-		t.Fatal("classical client connected to PQ-only server")
+	// Nothing is listening, so the dial times out rather than being refused.
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dead := netaddr.NewEndpointAddr(sk.Public().EndpointID()).WithIP(netip.MustParseAddrPort("127.0.0.1:1"))
+	if _, err := client.Connect(ctx, dead, "iroh-kx-test/0"); err == nil {
+		t.Fatal("dial to a dead address succeeded")
+	} else if errors.Is(err, ErrTLSHandshakeFailure) {
+		t.Errorf("Connect error = %v, want no ErrTLSHandshakeFailure match", err)
 	}
 }
 

--- a/iroh/router.go
+++ b/iroh/router.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 	"maps"
 	"net"
+	"slices"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -83,8 +86,19 @@ type RouterConfig struct {
 }
 
 // NewRouter registers every handler ALPN on ep, starts the accept loop, and
-// returns the running router. The endpoint must not already be listening (do not
-// pass [WithALPNs] to [Bind] when using a Router).
+// returns the running router. The endpoint must not already be listening, so it
+// must not have an accept loop of its own; see [Endpoint.Accept].
+//
+// The router replaces the endpoint's accepted ALPN set with the handler keys.
+// Passing [WithALPNs] to [Bind] is therefore only useful as a subset of them:
+// NewRouter returns an error naming any ALPN the endpoint was bound with that
+// has no handler, rather than negotiating a protocol it cannot dispatch. A
+// router with more ALPNs than the endpoint was bound with is fine and widens
+// the set.
+//
+// The rule is about what [Bind] was given, not about what the endpoint accepts
+// at the time. [Endpoint.SetALPNs] documents that it replaces the accepted set,
+// so a router replacing it again is that contract, not a mistake.
 //
 // The handlers map is keyed by exact ALPN string. ALPN values are opaque byte
 // strings represented as Go strings; printable ASCII protocol names are
@@ -102,6 +116,9 @@ func NewRouter(ep *Endpoint, handlers map[string]ProtocolHandler, cfg *RouterCon
 	}()
 
 	handlers = maps.Clone(handlers)
+	if orphans := alpnsWithoutHandler(ep.boundALPNs(), handlers); len(orphans) > 0 {
+		return nil, fmt.Errorf("iroh: new router: endpoint was bound with %s, which no handler serves", strings.Join(orphans, ", "))
+	}
 	logger := slog.Default()
 	filter := IncomingFilter(nil)
 	if cfg != nil {
@@ -342,4 +359,18 @@ func (r *Router) Shutdown(ctx context.Context) error {
 		return ctx.Err()
 	}
 	return closeErr
+}
+
+// alpnsWithoutHandler returns the ALPNs in alpns that handlers does not cover,
+// sorted and quoted for an error message. An ALPN with no handler would still
+// negotiate, then reach an accept loop with nothing to dispatch it to.
+func alpnsWithoutHandler(alpns []string, handlers map[string]ProtocolHandler) []string {
+	var orphans []string
+	for _, a := range alpns {
+		if _, ok := handlers[a]; !ok {
+			orphans = append(orphans, strconv.Quote(a))
+		}
+	}
+	slices.Sort(orphans)
+	return slices.Compact(orphans)
 }

--- a/iroh/router_test.go
+++ b/iroh/router_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -595,4 +596,88 @@ func TestRouterOnAccepting(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}
+}
+
+// TestRouterALPNsWithoutHandler checks the four combinations of a bound ALPN
+// set and a handler map. NewRouter replaces the endpoint's ALPN set with the
+// handler keys, so an ALPN the endpoint was bound with and the router cannot
+// dispatch used to be dropped silently; it is now an error.
+func TestRouterALPNsWithoutHandler(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	const (
+		alpnA = "iroh-router-alpn/a"
+		alpnB = "iroh-router-alpn/b"
+	)
+	for _, tt := range []struct {
+		name     string
+		bound    []string
+		handlers []string
+		wantErr  string
+	}{
+		{name: "no bound alpns", handlers: []string{alpnA, alpnB}},
+		{name: "identical sets", bound: []string{alpnA}, handlers: []string{alpnA}},
+		{name: "router widens", bound: []string{alpnA}, handlers: []string{alpnA, alpnB}},
+		{name: "bound alpn has no handler", bound: []string{alpnA, alpnB}, handlers: []string{alpnA}, wantErr: alpnB},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []Option{WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0))}
+			if len(tt.bound) > 0 {
+				opts = append(opts, WithALPNs(tt.bound...))
+			}
+			ep, err := Bind(ctx, opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ep.Shutdown(ctx)
+
+			handlers := make(map[string]ProtocolHandler, len(tt.handlers))
+			for _, a := range tt.handlers {
+				handlers[a] = echoHandler{}
+			}
+			router, err := NewRouter(ep, handlers, nil)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("NewRouter: %v", err)
+				}
+				defer router.Shutdown(ctx)
+				return
+			}
+			if err == nil {
+				router.Shutdown(ctx)
+				t.Fatal("NewRouter with an unhandled endpoint ALPN succeeded")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("NewRouter error = %v, want it to name %q", err, tt.wantErr)
+			}
+			// The endpoint keeps its own accept loop available.
+			if _, err := ep.ListenStreams(); err != nil {
+				t.Fatalf("ListenStreams after a rejected router: %v", err)
+			}
+		})
+	}
+}
+
+// TestRouterAfterSetALPNs checks that the unhandled-ALPN rule reads what Bind
+// was given, not what the endpoint accepts at the time. SetALPNs documents that
+// it replaces the accepted set, so a router replacing it again is that
+// contract, not a misconfiguration.
+func TestRouterAfterSetALPNs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	ep, err := Bind(ctx, WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ep.Shutdown(ctx)
+	if err := ep.SetALPNs([]string{"iroh-router-setalpns/a"}); err != nil {
+		t.Fatal(err)
+	}
+	router, err := NewRouter(ep, map[string]ProtocolHandler{"iroh-router-setalpns/b": echoHandler{}}, nil)
+	if err != nil {
+		t.Fatalf("NewRouter after SetALPNs: %v", err)
+	}
+	router.Shutdown(ctx)
 }


### PR DESCRIPTION
Resolves dials by endpoint ID through the address lookup, binds IPv4 on IPv4 sockets, rejects a router that cannot dispatch an ALPN, reports key exchange mismatch as ErrTLSHandshakeFailure, and adds WithQLOG.