### PR TITLE
docs, key, netaddr: document prefix shadowing and address forms

### DIFF
--- a/docs/doc.go
+++ b/docs/doc.go
@@ -4,6 +4,10 @@
 // capabilities out of band, an in-memory entry store, the iroh-docs sync
 // protocol over an iroh Router, and live synchronization over iroh-gossip.
 //
+// Keys form a prefix hierarchy per author: an entry shadows every entry of the
+// same author whose key it is a prefix of, so writing "menu" removes
+// "menu/tea". See [MemoryStore.Put].
+//
 // The Go API is not stable before v1 and may change in any v0 release; the
 // wire format tracks pinned upstream iroh-docs releases and does not.
 package docs

--- a/docs/store.go
+++ b/docs/store.go
@@ -242,6 +242,20 @@ func (s *MemoryStore) entriesLocked() []SignedEntry {
 }
 
 // Put inserts entry if it is newer than all matching parent entries.
+//
+// Keys form a prefix hierarchy per author, so an entry shadows its
+// descendants: writing "menu" for an author removes that author's "menu/tea"
+// and every other key under "menu", and a document cannot hold both. The insert
+// is dropped instead when an ancestor key is already present with a newer or
+// equal record. "Newer" is the record timestamp, with the content hash breaking
+// ties. Entries from different authors never shadow each other.
+//
+// This is the iroh-docs model, deliberate and how a subtree is deleted, but it
+// is silent: [InsertOutcome.Removed] reports how many entries a write deleted,
+// and nothing reports it to a later reader. A caller that wants "menu" and
+// "menu/tea" to coexist must keep the author's keys prefix-free, so that no key
+// is a prefix of another. Note that a trailing separator does not help: "menu/"
+// is still a prefix of "menu/tea".
 func (s *MemoryStore) Put(entry SignedEntry) InsertOutcome {
 	return s.PutWithOrigin(entry, InsertOrigin{Kind: InsertOriginLocal})
 }
@@ -251,7 +265,8 @@ func (s *MemoryStore) put(entry SignedEntry) InsertOutcome {
 	return outcome
 }
 
-// PutWithOrigin inserts entry with origin metadata for subscribers.
+// PutWithOrigin inserts entry with origin metadata for subscribers. It shadows
+// descendant keys exactly as [MemoryStore.Put] does.
 func (s *MemoryStore) PutWithOrigin(entry SignedEntry, origin InsertOrigin) InsertOutcome {
 	outcome, event, events := s.putEntry(entry, origin, true)
 	if outcome.Inserted() && s.persistPath != "" {

--- a/docs/store_test.go
+++ b/docs/store_test.go
@@ -214,3 +214,33 @@ func testSignedEntry(namespace NamespaceSecret, author Author, key string, recor
 func testRecord(seed string, length, timestamp uint64) Record {
 	return NewRecord(blobs.NewHash([]byte(seed)), length, timestamp)
 }
+
+// TestMemoryStorePrefixShadowing pins the documented surprise: a plain write to
+// a key that is a prefix of an existing key from the same author deletes the
+// longer entry, so the two cannot coexist. TestMemoryStorePrefixDeletion covers
+// the deliberate tombstone use of the same rule; this covers the accident.
+func TestMemoryStorePrefixShadowing(t *testing.T) {
+	namespace := NewNamespaceSecret(repeat32(0xb2))
+	author := NewAuthor(repeat32(0xa1))
+	store := NewMemoryStore()
+
+	store.Put(testSignedEntry(namespace, author, "menu/tea", testRecord("tea", 1, 1)))
+	got := store.Put(testSignedEntry(namespace, author, "menu", testRecord("menu", 1, 2)))
+	if !got.Inserted() || got.Removed() != 1 {
+		t.Fatalf("Put(menu) = inserted %v removed %d, want true 1", got.Inserted(), got.Removed())
+	}
+	if _, ok := store.GetExact(namespace.ID(), author.ID(), []byte("menu/tea"), false); ok {
+		t.Fatal("menu/tea survived a write to menu")
+	}
+
+	// A trailing separator does not avoid it: "menu/" is still a prefix.
+	store.Put(testSignedEntry(namespace, author, "menu/tea", testRecord("tea", 1, 3)))
+	if got := store.Put(testSignedEntry(namespace, author, "menu/", testRecord("menu", 1, 4))); got.Removed() != 1 {
+		t.Fatalf("Put(menu/) removed %d, want 1", got.Removed())
+	}
+
+	// The write is dropped outright when the ancestor is the newer entry.
+	if got := store.Put(testSignedEntry(namespace, author, "menu/coffee", testRecord("coffee", 1, 2))); got.Inserted() {
+		t.Fatal("insert under a newer ancestor was accepted")
+	}
+}

--- a/key/key.go
+++ b/key/key.go
@@ -186,13 +186,16 @@ func (id EndpointID) String() string { return id.PublicKey().String() }
 func (id EndpointID) Short() string { return id.PublicKey().Short() }
 
 // Z32 encodes the endpoint id in z-base-32, the encoding used by pkarr domain
-// names.
+// names. It uses a different alphabet from the RFC 4648 base32 accepted by
+// [ParseEndpointID] and is the same length, so the two cannot be told apart:
+// parse the result with [ParseEndpointIDZ32], not [ParseEndpointID].
 func (id EndpointID) Z32() string {
 	k := id.PublicKey()
 	return encodeZBase32(k.bytes[:])
 }
 
-// ParseEndpointIDZ32 parses an endpoint id from its z-base-32 encoding.
+// ParseEndpointIDZ32 parses an endpoint id from the z-base-32 encoding produced
+// by [EndpointID.Z32].
 func ParseEndpointIDZ32(s string) (EndpointID, error) {
 	b, err := decodeZBase32(s)
 	if err != nil {
@@ -204,7 +207,8 @@ func ParseEndpointIDZ32(s string) (EndpointID, error) {
 // ParsePublicKey parses a PublicKey from its hex or base32 string form. A string
 // of exactly 64 characters is decoded as lowercase hex; otherwise it is decoded
 // as RFC 4648 base32 (no padding, case-insensitive). [PublicKey.String] always
-// produces the hex form.
+// produces the hex form. The z-base-32 form is not accepted; see
+// [ParseEndpointID].
 func ParsePublicKey(s string) (PublicKey, error) {
 	b, err := decodeBase32OrHex(s)
 	if err != nil {
@@ -213,10 +217,21 @@ func ParsePublicKey(s string) (PublicKey, error) {
 	return NewPublicKey(b)
 }
 
-// ParseEndpointID parses an EndpointID from its hex or base32 string form.
+// ParseEndpointID parses an EndpointID from its hex or RFC 4648 base32 string
+// form: the forms [EndpointID.String] and upstream iroh produce.
+//
+// It does not accept the z-base-32 form produced by [EndpointID.Z32]. Both
+// base32 flavours encode an endpoint id in 52 characters but with different
+// alphabets, so a z-base-32 id cannot be recognized reliably — some decode
+// under RFC 4648 to a different, equally valid-looking id. Use
+// [ParseEndpointIDZ32] for that form. When the input fails to parse but is
+// well-formed z-base-32, the returned error says so.
 func ParseEndpointID(s string) (EndpointID, error) {
 	k, err := ParsePublicKey(s)
 	if err != nil {
+		if b, zerr := decodeZBase32(s); zerr == nil && len(b) == PublicKeySize {
+			return EndpointID{}, fmt.Errorf("%w: input is z-base-32, use ParseEndpointIDZ32", err)
+		}
 		return EndpointID{}, err
 	}
 	return k.EndpointID(), nil

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -268,6 +268,42 @@ func TestPublicKeyBinary(t *testing.T) {
 	}
 }
 
+// TestParseEndpointIDRejectsZ32 pins the reason ParseEndpointID must not learn
+// to accept z-base-32: both encodings render 32 bytes in 52 characters and
+// share 29 of 32 symbols, so the two cannot be distinguished. A z-base-32 id
+// usually fails to decode as RFC 4648 base32, and occasionally decodes to a
+// different, equally well-formed endpoint id.
+func TestParseEndpointIDRejectsZ32(t *testing.T) {
+	// Uses a symbol ("8") that exists only in the z-base-32 alphabet.
+	const rejected = "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo"
+	want, err := ParseEndpointIDZ32(rejected)
+	if err != nil {
+		t.Fatalf("ParseEndpointIDZ32(%q): %v", rejected, err)
+	}
+	if _, err := ParseEndpointID(rejected); !errors.Is(err, ErrDecodeBase32) {
+		t.Errorf("ParseEndpointID(z32) error = %v, want ErrDecodeBase32", err)
+	}
+	if _, err := ParseEndpointID(want.String()); err != nil {
+		t.Errorf("ParseEndpointID(hex): %v", err)
+	}
+
+	// Drawn from the ~1-in-170 z-base-32 ids whose symbols all exist in the
+	// RFC 4648 alphabet too. These decode without error to the wrong id, which
+	// is why auto-detection cannot be added.
+	const ambiguous = "bf4nc56yxomts6n7whnrmotaqs7pgro36xdgeenscw4fdd3gexgy"
+	z32ID, err := ParseEndpointIDZ32(ambiguous)
+	if err != nil {
+		t.Fatalf("ParseEndpointIDZ32(%q): %v", ambiguous, err)
+	}
+	rfcID, err := ParseEndpointID(ambiguous)
+	if err != nil {
+		t.Fatalf("ParseEndpointID(%q): %v", ambiguous, err)
+	}
+	if rfcID.Equal(z32ID) {
+		t.Fatal("fixture is no longer ambiguous between the two base32 alphabets")
+	}
+}
+
 func TestEndpointIDEncoding(t *testing.T) {
 	sk, _ := GenerateSecretKey()
 	id := sk.Public().EndpointID()

--- a/netaddr/endpointaddr.go
+++ b/netaddr/endpointaddr.go
@@ -22,7 +22,12 @@ import (
 type TransportAddr interface {
 	// Network returns the transport kind: "relay", "ip", or "custom".
 	Network() string
-	// String renders the address in its "kind:value" form, e.g. "ip:127.0.0.1:9".
+	// String renders the address for display and for the text encodings in
+	// this module. [RelayAddr] and [IPAddr] use the "kind:value" form, e.g.
+	// "ip:127.0.0.1:9"; [CustomAddr] omits the prefix and renders as
+	// "<id>_<data>", matching upstream iroh's CustomAddr Display and the DNS
+	// TXT encoding in [github.com/tmc/go-iroh/dns]. [ParseTransportAddr]
+	// accepts every form String produces, so String round-trips.
 	String() string
 	// Compare returns -1, 0, or +1 ordering this address against other. The
 	// order matches the Rust reference's derived Ord on the TransportAddr enum:
@@ -67,16 +72,12 @@ type IPAddr struct{ Addr netip.AddrPort }
 //
 // String encoding ([CustomAddr.String], [ParseCustomAddr]): "<id>_<data>" where
 // <id> is the transport ID as lowercase hex (no "0x", no leading zeros) and
-// <data> is the address bytes as lowercase hex.
+// <data> is the address bytes as lowercase hex. Unlike [RelayAddr] and
+// [IPAddr], a CustomAddr carries no "custom:" kind prefix; see
+// [CustomAddr.String].
 //
 // Binary encoding ([CustomAddr.MarshalBinary], [CustomAddr.UnmarshalBinary]):
 // 8-byte little-endian u64 ID followed by the raw data bytes (minimum 8 bytes).
-//
-// CustomAddr mirrors upstream iroh's experimental custom-transport address
-// surface, which upstream excludes from its stability guarantees. The Go API
-// below follows this module's normal compatibility policy, but the
-// endpoint-ticket wire encoding of a CustomAddr may change to track upstream
-// without a major go-iroh version bump.
 type CustomAddr struct {
 	id   uint64
 	data []byte
@@ -90,8 +91,18 @@ func (RelayAddr) Network() string  { return "relay" }
 func (IPAddr) Network() string     { return "ip" }
 func (CustomAddr) Network() string { return "custom" }
 
-func (a RelayAddr) String() string  { return "relay:" + a.URL.String() }
-func (a IPAddr) String() string     { return "ip:" + a.Addr.String() }
+func (a RelayAddr) String() string { return "relay:" + a.URL.String() }
+func (a IPAddr) String() string    { return "ip:" + a.Addr.String() }
+
+// String returns the address as "<id>_<data>": the transport ID in lowercase
+// hex followed by the address data in lowercase hex.
+//
+// It deliberately omits the "custom:" prefix that [RelayAddr] and [IPAddr]
+// carry. This is the form upstream iroh's CustomAddr Display produces and the
+// form written to DNS TXT records by [github.com/tmc/go-iroh/dns], so adding a
+// prefix here would change a wire encoding. [ParseCustomAddr] and
+// [ParseTransportAddr] accept the address with or without the prefix, so
+// String still round-trips through either.
 func (a CustomAddr) String() string { return a.customString() }
 
 // MarshalText implements encoding.TextMarshaler using the string encoding

--- a/netaddr/endpointaddr_test.go
+++ b/netaddr/endpointaddr_test.go
@@ -134,6 +134,28 @@ func TestTransportAddrStringRoundTrip(t *testing.T) {
 	}
 }
 
+// TestCustomAddrStringPrefix pins the documented divergence: a CustomAddr
+// renders without the "kind:" prefix its siblings carry, because that is the
+// form on the DNS TXT wire, and both spellings parse back to the same address.
+func TestCustomAddrStringPrefix(t *testing.T) {
+	a := NewCustomAddr(7, []byte{0xde, 0xad})
+	if got, want := a.String(), "7_dead"; got != want {
+		t.Errorf("CustomAddr.String() = %q, want %q", got, want)
+	}
+	if got, want := a.Network(), "custom"; got != want {
+		t.Errorf("CustomAddr.Network() = %q, want %q", got, want)
+	}
+	for _, s := range []string{"7_dead", "custom:7_dead"} {
+		parsed, err := ParseTransportAddr(s)
+		if err != nil {
+			t.Fatalf("ParseTransportAddr(%q): %v", s, err)
+		}
+		if parsed.Compare(a) != 0 {
+			t.Errorf("ParseTransportAddr(%q) = %v, want %v", s, parsed, a)
+		}
+	}
+}
+
 func TestTransportAddrNetAddr(t *testing.T) {
 	var (
 		_ net.Addr = RelayAddr{}


### PR DESCRIPTION
Documents prefix shadowing on Put, which base32 ParseEndpointID accepts, and CustomAddr's unprefixed string form.