### PR TITLE
examples: add runnable examples

### DIFF
--- a/dns/example_test.go
+++ b/dns/example_test.go
@@ -1,0 +1,20 @@
+package dns_test
+
+import (
+	"fmt"
+	"net/netip"
+
+	"github.com/tmc/go-iroh/dns"
+)
+
+func ExampleEndpointData() {
+	data := dns.NewEndpointData()
+	data.AddIPAddrs(netip.MustParseAddrPort("192.0.2.1:443"))
+	user, err := dns.NewUserData("device=laptop")
+	if err != nil {
+		panic(err)
+	}
+	data.SetUserData(&user)
+	fmt.Println(data.IPAddrs()[0], data.UserData())
+	// Output: 192.0.2.1:443 device=laptop
+}

--- a/iroh/example_test.go
+++ b/iroh/example_test.go
@@ -5,12 +5,45 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"os"
 
 	"github.com/tmc/go-iroh/iroh"
 	"github.com/tmc/go-iroh/key"
 	"github.com/tmc/go-iroh/netaddr"
 	"github.com/tmc/go-iroh/relay"
 )
+
+// ExampleQLOGDir installs a per-endpoint qlog sink. The same sink can be
+// passed to several endpoints when their traces belong in one directory.
+func ExampleQLOGDir() {
+	dir, err := os.MkdirTemp("", "iroh-qlog-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	sink := iroh.QLOGDir(dir)
+	w := sink(context.Background(), iroh.QLOGConnection{
+		ConnectionID: "0102",
+		Client:       true,
+	})
+	if w == nil {
+		panic("create qlog")
+	}
+	if _, err := io.WriteString(w, "trace"); err != nil {
+		panic(err)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(entries[0].Name())
+	// Output: 0102_client.sqlog
+}
 
 // ExampleEndpoint_Online binds an endpoint that uses the n0 staging relays and
 // waits until it has a connected home relay before dialing.
@@ -96,6 +129,55 @@ func ExampleEndpoint_RemoteInfo() {
 	// true true true
 }
 
+// ExampleEndpoint_Connect_addressLookup dials a peer using only its endpoint
+// ID after an address lookup service supplies its transport address.
+func ExampleEndpoint_Connect_addressLookup() {
+	ctx := context.Background()
+	const alpn = "iroh/address-lookup/1"
+
+	server, err := iroh.Bind(ctx,
+		iroh.WithALPNs(alpn),
+		iroh.WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer server.Shutdown(ctx)
+
+	lookup := iroh.NewMemoryLookup()
+	lookup.AddEndpointAddr(netaddr.NewEndpointAddr(server.ID()).WithIP(server.LocalAddr()))
+	var services iroh.AddressLookupServices
+	services.AddResolver(lookup)
+	client, err := iroh.Bind(ctx,
+		iroh.WithAddressLookup(&services),
+		iroh.WithBindAddr(netip.AddrPortFrom(netip.IPv6Loopback(), 0)),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Shutdown(ctx)
+
+	accepted := make(chan *iroh.Conn, 1)
+	go func() {
+		conn, err := server.Accept(ctx)
+		if err != nil {
+			close(accepted)
+			return
+		}
+		accepted <- conn
+	}()
+	conn, err := client.Connect(ctx, netaddr.NewEndpointAddr(server.ID()), alpn)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.CloseWithError(0, "")
+	if server := <-accepted; server != nil {
+		defer server.CloseWithError(0, "")
+	}
+	fmt.Println(conn.RemoteID() == server.ID())
+	// Output: true
+}
+
 func echo(ctx context.Context, conn *iroh.Conn) error {
 	s, err := conn.AcceptStream(ctx)
 	if err != nil {
@@ -148,7 +230,9 @@ func ExampleRouter() {
 
 	s, _ := conn.OpenStreamSync(ctx)
 	s.Write([]byte("hello"))
-	s.Close()
+	// CloseWrite tells the server that the request is complete while leaving
+	// the read side open for its response.
+	s.CloseWrite()
 	got, _ := io.ReadAll(s)
 	fmt.Printf("%s\n", got)
 	// Output: hello

--- a/iroh/mdns/example_test.go
+++ b/iroh/mdns/example_test.go
@@ -3,6 +3,8 @@ package mdns_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 
 	"github.com/tmc/go-iroh/iroh"
 	"github.com/tmc/go-iroh/iroh/mdns"
@@ -13,8 +15,12 @@ func ExampleDiscovery() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	sk, _ := key.GenerateSecretKey()
-	discovery := mdns.New(sk.Public().EndpointID())
+	sk, err := key.GenerateSecretKey()
+	if err != nil {
+		panic(err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	discovery := mdns.New(sk.Public().EndpointID(), mdns.WithLogger(logger))
 	go func() { _ = discovery.Start(ctx) }()
 
 	var services iroh.AddressLookupServices

--- a/key/example_test.go
+++ b/key/example_test.go
@@ -1,0 +1,18 @@
+package key_test
+
+import (
+	"fmt"
+
+	"github.com/tmc/go-iroh/key"
+)
+
+func ExampleSecretKey_Sign() {
+	secret, err := key.GenerateSecretKey()
+	if err != nil {
+		panic(err)
+	}
+	message := []byte("hello")
+	signature := secret.Sign(message)
+	fmt.Println(secret.Public().Verify(message, signature) == nil)
+	// Output: true
+}

--- a/metrics/example_test.go
+++ b/metrics/example_test.go
@@ -1,0 +1,30 @@
+package metrics_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tmc/go-iroh/metrics"
+)
+
+type requests struct{ n uint64 }
+
+func (r requests) Snapshot() metrics.Snapshot {
+	return metrics.Snapshot{"requests": r.n}
+}
+
+func ExampleRegistry() {
+	registry := metrics.NewRegistry()
+	if err := registry.Register("server", requests{n: 3}); err != nil {
+		panic(err)
+	}
+	if err := registry.WriteOpenMetrics(os.Stdout); err != nil {
+		panic(err)
+	}
+	fmt.Println("done")
+	// Output:
+	// # TYPE server_requests counter
+	// server_requests_total 3
+	// # EOF
+	// done
+}

--- a/netaddr/example_test.go
+++ b/netaddr/example_test.go
@@ -1,0 +1,17 @@
+package netaddr_test
+
+import (
+	"fmt"
+
+	"github.com/tmc/go-iroh/netaddr"
+)
+
+func ExampleParseTransportAddr() {
+	addr, err := netaddr.ParseTransportAddr("2a_deadbeef")
+	if err != nil {
+		panic(err)
+	}
+	custom := addr.(netaddr.CustomAddr)
+	fmt.Println(custom.ID(), custom.Data())
+	// Output: 42 [222 173 190 239]
+}

--- a/postcard/example_test.go
+++ b/postcard/example_test.go
@@ -1,0 +1,26 @@
+package postcard_test
+
+import (
+	"fmt"
+
+	"github.com/tmc/go-iroh/postcard"
+)
+
+func Example() {
+	type message struct {
+		Unsigned uint8
+		Signed   int8
+		Text     string
+	}
+	in := message{Unsigned: 200, Signed: -1, Text: "hello"}
+	b, err := postcard.Marshal(in)
+	if err != nil {
+		panic(err)
+	}
+	var out message
+	if err := postcard.Unmarshal(b, &out); err != nil {
+		panic(err)
+	}
+	fmt.Println(out, b[:2])
+	// Output: {200 -1 hello} [200 255]
+}

--- a/relay/example_test.go
+++ b/relay/example_test.go
@@ -1,0 +1,33 @@
+package relay_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tmc/go-iroh/netaddr"
+	"github.com/tmc/go-iroh/relay"
+)
+
+func ExampleMap_Nearest() {
+	near, err := netaddr.ParseRelayURL("https://near.example")
+	if err != nil {
+		panic(err)
+	}
+	far, err := netaddr.ParseRelayURL("https://far.example")
+	if err != nil {
+		panic(err)
+	}
+	m := relay.MapFromURLs(far, near)
+	got, err := m.Nearest(context.Background(), func(_ context.Context, u netaddr.RelayURL) (time.Duration, error) {
+		if u.Equal(near) {
+			return time.Millisecond, nil
+		}
+		return 10 * time.Millisecond, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(got)
+	// Output: https://near.example/
+}

--- a/relayserver/example_test.go
+++ b/relayserver/example_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/tmc/go-iroh/relayserver"
 )
 
-func ExampleNew() {
-	srv := httptest.NewServer(relayserver.New())
+func ExampleNewWithOptions() {
+	// Override the default per-client receive rate when hosting the relay.
+	srv := httptest.NewServer(relayserver.NewWithOptions(relayserver.WithClientRate(8 << 20)))
 	defer srv.Close()
 
 	resp, err := http.Get(srv.URL + "/")

--- a/watch/example_test.go
+++ b/watch/example_test.go
@@ -1,0 +1,23 @@
+package watch_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tmc/go-iroh/watch"
+)
+
+func ExampleValue() {
+	value := watch.NewValue("starting")
+	observer := value.Watch()
+	fmt.Println(observer.Current())
+	value.Set("ready")
+	updated, err := observer.Updated(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(updated)
+	// Output:
+	// starting
+	// ready
+}


### PR DESCRIPTION
Adds runnable examples for dns, iroh, iroh/mdns, key, metrics, netaddr, postcard, relay, relayserver, and watch.