### PR TITLE
all: fixes from code review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Review instructions for go-iroh
+
+A pure-Go port of [iroh](https://github.com/n0-computer/iroh): QUIC connections
+between endpoints identified by public key, with relay fallback. One module, no
+dependencies outside `golang.org/x/*`.
+
+Review as the Go project would: see [Go Code Review
+Comments](https://go.dev/wiki/CodeReviewComments). Prefer specific findings
+about correctness, compatibility, and documentation accuracy over style notes.
+
+## Compatibility
+
+Pre-1.0. A patch release (v0.1.x) may add exported symbols but never remove one
+or change its type; a minor release (v0.2.0) may break. See [Keeping your
+modules compatible](https://go.dev/blog/module-compatibility) and [Go 1 and the
+Future of Go Programs](https://go.dev/doc/go1compat).
+
+Flag anything that stops downstream code compiling, and name which use breaks —
+the last three are *additions*, which
+[gorelease](https://pkg.go.dev/golang.org/x/exp/cmd/gorelease) reports as
+compatible:
+
+- **call-breaking** — symbol removed or renamed, parameter list changed.
+- **value-breaking** — the function's type changes, so `var f func() *T = New`
+  fails though every call still compiles. Adding variadic options does this.
+- **literal-breaking** — a new exported struct field breaks unkeyed literals.
+- **implementer-breaking** — a new interface method breaks outside implementers.
+- **embed-breaking** — a new name collides in types that embed this one.
+
+## Documentation
+
+Doc comments follow [go.dev/doc/comment](https://go.dev/doc/comment).
+
+Doc links and README prose are not compiled, so an exported identifier named in
+either can silently go missing. Report identifiers that do not exist in the tree.
+
+Check each doc comment against the code: report where it claims more than the
+implementation does — an unconditional rule where the code has a condition, an
+invariant the code does not maintain, a hard-coded constant that will drift from
+its named default. This is the most useful review this repo gets.
+
+## Examples
+
+`example_test.go` files are documentation and readers copy them (see
+[testable examples](https://go.dev/blog/examples)). Hold them above test code:
+no discarded errors, no value used before its error is checked, no cleanup that
+can panic on a nil returned alongside an error.
+
+## internal/qng
+
+A vendored fork of [quic-go](https://github.com/quic-go/quic-go), kept close to
+upstream so new releases can be merged; `anchor.go` records the base release.
+Do not suggest renames or idiomatic rewrites there — divergence costs us at
+every merge. Do report defects, and say whether the code is upstream's or the
+fork's, since fork code often mirrors an upstream function and can still carry a
+bug upstream already fixed.
+
+## Concurrency
+
+Report races, lock-ordering problems, and state read outside its guarding lock;
+run findings against the [Go Memory Model](https://go.dev/ref/mem). Tests that
+infer blocking from elapsed time are flaky under CI load — prefer synchronising
+on the event.

--- a/docs/doc.go
+++ b/docs/doc.go
@@ -5,8 +5,8 @@
 // protocol over an iroh Router, and live synchronization over iroh-gossip.
 //
 // Keys form a prefix hierarchy per author: an entry shadows every entry of the
-// same author whose key it is a prefix of, so writing "menu" removes
-// "menu/tea". See [MemoryStore.Put].
+// same author whose key it is a prefix of and whose record is not newer, so
+// writing "menu" removes "menu/tea". See [MemoryStore.Put].
 //
 // The Go API is not stable before v1 and may change in any v0 release; the
 // wire format tracks pinned upstream iroh-docs releases and does not.

--- a/docs/store.go
+++ b/docs/store.go
@@ -245,10 +245,12 @@ func (s *MemoryStore) entriesLocked() []SignedEntry {
 //
 // Keys form a prefix hierarchy per author, so an entry shadows its
 // descendants: writing "menu" for an author removes that author's "menu/tea"
-// and every other key under "menu", and a document cannot hold both. The insert
-// is dropped instead when an ancestor key is already present with a newer or
-// equal record. "Newer" is the record timestamp, with the content hash breaking
-// ties. Entries from different authors never shadow each other.
+// and every other key under "menu" whose record is older than or equal to the
+// one being written. A descendant with a newer record is left alone, so the two
+// do coexist in that case. The insert is dropped instead when an ancestor key
+// is already present with a newer or equal record. "Newer" is the record
+// timestamp, with the content hash breaking ties. Entries from different
+// authors never shadow each other.
 //
 // This is the iroh-docs model, deliberate and how a subtree is deleted, but it
 // is silent: [InsertOutcome.Removed] reports how many entries a write deleted,

--- a/docs/store_test.go
+++ b/docs/store_test.go
@@ -216,8 +216,8 @@ func testRecord(seed string, length, timestamp uint64) Record {
 }
 
 // TestMemoryStorePrefixShadowing pins the documented surprise: a plain write to
-// a key that is a prefix of an existing key from the same author deletes the
-// longer entry, so the two cannot coexist. TestMemoryStorePrefixDeletion covers
+// a key that is a prefix of an existing, not newer key from the same author
+// deletes the longer entry, so the two do not coexist. TestMemoryStorePrefixDeletion covers
 // the deliberate tombstone use of the same rule; this covers the accident.
 func TestMemoryStorePrefixShadowing(t *testing.T) {
 	namespace := NewNamespaceSecret(repeat32(0xb2))

--- a/gossip/topic.go
+++ b/gossip/topic.go
@@ -691,12 +691,13 @@ func (r *Receiver) Joined(ctx context.Context) error {
 		// missed until the next change.
 		g.mu.Lock()
 		wait := g.joinWaiter()
+		joined := len(g.neighbors[r.topic.id]) > 0
 		g.mu.Unlock()
-		if r.IsJoined() {
-			return nil
-		}
 		if r.topic.isClosed() {
 			return errors.New("gossip: topic closed")
+		}
+		if joined {
+			return nil
 		}
 		select {
 		case <-ctx.Done():

--- a/iroh/mdns/mdns.go
+++ b/iroh/mdns/mdns.go
@@ -347,7 +347,16 @@ func (d *Discovery) respond(answer []byte) {
 	timer := time.NewTimer(d.responseDelay())
 	defer timer.Stop()
 	<-timer.C
-	d.writeMulticast(answer)
+	// Answer only on the socket Start opened. writeMulticast falls back to a
+	// fresh socket when there is none, which would multicast a response after
+	// Start has returned.
+	d.mu.RLock()
+	conn := d.conn
+	d.mu.RUnlock()
+	if conn == nil {
+		return
+	}
+	_, _ = conn.WriteToUDPAddrPort(answer, ipv4Multicast)
 }
 
 func (d *Discovery) query(id key.EndpointID) {

--- a/iroh/qlog_test.go
+++ b/iroh/qlog_test.go
@@ -42,35 +42,50 @@ func TestQLOGDIRWritesTraces(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Close on every path out of the test, including a t.Fatal below; the
+	// second close is a no-op.
 	defer conn.CloseWithError(0, "")
 	if err := <-accepted; err != nil {
 		t.Fatal(err)
 	}
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
+	// The traces are written through a buffer that is flushed when the
+	// connection ends, so close first and then wait for the flush to land.
+	if err := conn.CloseWithError(0, ""); err != nil {
 		t.Fatal(err)
 	}
+
 	var client0, server0 string
-	for _, e := range entries {
-		switch {
-		case strings.HasSuffix(e.Name(), "_client.sqlog"):
-			client0 = strings.TrimSuffix(e.Name(), "_client.sqlog")
-		case strings.HasSuffix(e.Name(), "_server.sqlog"):
-			server0 = strings.TrimSuffix(e.Name(), "_server.sqlog")
+	var b []byte
+	for {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
-	if client0 == "" || server0 == "" {
-		t.Fatalf("QLOGDIR=%s holds %v, want a _client.sqlog and a _server.sqlog", dir, entries)
+		client0, server0 = "", ""
+		for _, e := range entries {
+			switch {
+			case strings.HasSuffix(e.Name(), "_client.sqlog"):
+				client0 = strings.TrimSuffix(e.Name(), "_client.sqlog")
+			case strings.HasSuffix(e.Name(), "_server.sqlog"):
+				server0 = strings.TrimSuffix(e.Name(), "_server.sqlog")
+			}
+		}
+		if client0 != "" && server0 != "" {
+			b, err = os.ReadFile(filepath.Join(dir, client0+"_client.sqlog"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), `"vantage_point":{"type":"client"}`) {
+				break
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("QLOGDIR=%s holds %v, want a flushed _client.sqlog and _server.sqlog: %v", dir, entries, ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 	if client0 != server0 {
 		t.Errorf("trace ids differ: client %q, server %q; the two ends share the original destination connection id", client0, server0)
-	}
-	b, err := os.ReadFile(filepath.Join(dir, client0+"_client.sqlog"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(b), `"vantage_point":{"type":"client"}`) {
-		t.Errorf("client trace does not declare a client vantage point")
 	}
 }


### PR DESCRIPTION
Four fixes raised in review on the merged v0.1.1 PRs, plus review instructions for Copilot. None change an API.

- gossip: `Receiver.Joined` checked closed after joined, and allocated a slice to test for emptiness.
- iroh/mdns: a delayed answer could open a fresh socket and multicast after `Start` returned.
- docs: prefix shadowing is conditional on record order; three comments said it was unconditional.
- iroh: `TestQLOGDIRWritesTraces` read the trace before the writer flushed.
- .github: `copilot-instructions.md`, so review findings land on correctness and compatibility.